### PR TITLE
Fix client search and add admin global search

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -61,15 +61,27 @@
         </h3>
 
         <div class="flex items-center gap-3 w-full md:w-auto">
-            <form method="get"
-                  class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[420px] focus-within:border-white/20">
+            <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[260px] focus-within:border-white/20">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="11" cy="11" r="8" />
                     <path d="m21 21-4.3-4.3" />
                 </svg>
-                <input name="q" value="@Model.Q" placeholder="Search clients..."
+                <input id="clientFilter" placeholder="Search clients..."
                        class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-            </form>
+            </div>
+
+            @if (User.IsInRole("assistant-admin"))
+            {
+                <form method="get"
+                      class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[260px] focus-within:border-white/20">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8" />
+                        <path d="m21 21-4.3-4.3" />
+                    </svg>
+                    <input name="q" value="@Model.Q" placeholder="Search all realms..."
+                           class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
+                </form>
+            }
 
             <a asp-page="/Clients/Create" class="btn-primary">
                 Создать клиента
@@ -107,7 +119,9 @@ else if (Model.Clients.Any())
             // один раз материализуем, чтобы не итерировать несколько раз
             var envList = Envs(c.Realm).ToList();
 
-            <a asp-page="/Clients/Details" asp-route-realm="@c.Realm" asp-route-clientId="@c.ClientId" class="block group">
+            <a asp-page="/Clients/Details" asp-route-realm="@c.Realm" asp-route-clientId="@c.ClientId"
+               class="block group client-card"
+               data-search="@($"{c.ClientId} {c.Realm} {DescFor(c.ClientId)}")">
                 <div class="kc-card kc-card--hover p-5 h-44 overflow-hidden transition relative">
                     <!-- лёгкая подсветка по ховеру -->
                     <div class="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition duration-500"
@@ -155,3 +169,20 @@ else if (Model.Clients.Any())
         }
     </div>
 }
+
+<script>
+    (() => {
+        const input = document.getElementById('clientFilter');
+        if (!input) return;
+        const cards = Array.from(document.querySelectorAll('.client-card'));
+        const applyFilter = () => {
+            const q = input.value.trim().toLowerCase();
+            cards.forEach(c => {
+                const hay = (c.dataset.search || '').toLowerCase();
+                const match = !q || hay.includes(q);
+                c.classList.toggle('hidden', !match);
+            });
+        };
+        input.addEventListener('input', applyFilter);
+    })();
+</script>

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -56,14 +56,7 @@ namespace Assistant.Pages
                 return;
             }
 
-            var all = await _provider.GetClientsForUser(User);
-            Clients = string.IsNullOrEmpty(Q)
-                ? all.ToList()
-                : all.Where(c =>
-                    (c.Name?.Contains(Q, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.ClientId?.Contains(Q, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Realm?.Contains(Q, StringComparison.OrdinalIgnoreCase) ?? false)
-                  ).ToList();
+            Clients = (await _provider.GetClientsForUser(User)).ToList();
             ShowEmptyMessage = true;
         }
     }


### PR DESCRIPTION
## Summary
- enable client-side filtering of visible clients
- add separate admin search across realms

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b53cbf8c832d84ac8fba4687df6c