### PR TITLE
Add global spinner for external requests

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -30,8 +30,11 @@
     <main id="app" class="container mx-auto px-4 md:px-6 py-6">
         @RenderBody()
     </main>
+    <div id="globalSpinner" class="fixed inset-0 bg-slate-900/40 flex items-center justify-center z-50 hidden">
+        <div class="w-16 h-16 border-4 border-slate-300 border-t-transparent rounded-full animate-spin"></div>
+    </div>
     <script>
-        (() => 
+        (() =>
         {
           document.addEventListener('keydown', e => 
           { if (e.key === 'Enter' && e.target.tagName !== 'TEXTAREA') e.preventDefault(); }, true);
@@ -91,6 +94,26 @@
             e.preventDefault();
             leave(a.href);
           }, true);
+
+          // ===== Global loading spinner for external requests =====
+          const spinner = document.getElementById('globalSpinner');
+          let pending = 0;
+          function updateSpinner() {
+            if (!spinner) return;
+            spinner.classList.toggle('hidden', pending === 0);
+          }
+          const origFetch = window.fetch;
+          window.fetch = async (...args) => {
+            pending++;
+            updateSpinner();
+            try {
+              return await origFetch(...args);
+            } finally {
+              pending--;
+              if (pending < 0) pending = 0;
+              updateSpinner();
+            }
+          };
         })();
     </script>
 


### PR DESCRIPTION
## Summary
- show a full-page spinner overlay
- intercept fetch to toggle spinner during external requests

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0 / resolved via installing sdk 9.0)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68c5bc163d74832d98233dc9f083ef83