### PR TITLE
feat: display spinner for XMLHttpRequest requests

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -114,8 +114,25 @@
               updateSpinner();
             }
           };
+
+          // also track XMLHttpRequest calls
+          if (window.XMLHttpRequest) {
+            const origOpen = XMLHttpRequest.prototype.open;
+            XMLHttpRequest.prototype.open = function(...a) {
+              this.addEventListener('loadstart', () => {
+                pending++;
+                updateSpinner();
+              });
+              this.addEventListener('loadend', () => {
+                pending--;
+                if (pending < 0) pending = 0;
+                updateSpinner();
+              });
+              return origOpen.apply(this, a);
+            };
+          }
         })();
-    </script>
+      </script>
 
     @RenderSection("Scripts", required: false)
 </body>


### PR DESCRIPTION
## Summary
- extend global loading spinner to monitor `XMLHttpRequest` network calls

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: .NET SDK 8.0 doesn't support .NET 9.0 target)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6104fddb0832d84a7fd550d721243