### PR TITLE
Add pagination to client list

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -168,6 +168,23 @@ else if (Model.Clients.Any())
             </a>
         }
     </div>
+
+    @if (Model.TotalPages > 1)
+    {
+        <div class="flex justify-center mt-6">
+            <nav class="flex items-center gap-2">
+                @if (Model.HasPreviousPage)
+                {
+                    <a asp-page="./Index" asp-route-q="@Model.Q" asp-route-page="@(Model.PageNumber - 1)" class="btn-subtle">Previous</a>
+                }
+                <span class="text-sm text-slate-400">Page @Model.PageNumber of @Model.TotalPages</span>
+                @if (Model.HasNextPage)
+                {
+                    <a asp-page="./Index" asp-route-q="@Model.Q" asp-route-page="@(Model.PageNumber + 1)" class="btn-subtle">Next</a>
+                }
+            </nav>
+        </div>
+    }
 }
 
 <script>

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -19,21 +19,28 @@ namespace Assistant.Pages
             _clients = clients;
         }
 
+        private const int PageSize = 20;
+
         public List<ClientSummary> Clients { get; private set; } = [];
         public string? Q { get; private set; }
         public bool ShowEmptyMessage { get; private set; }
+        public int PageNumber { get; private set; }
+        public int TotalPages { get; private set; }
+        public bool HasPreviousPage => PageNumber > 1;
+        public bool HasNextPage => PageNumber < TotalPages;
 
-        public async Task OnGetAsync(string? q)
+        public async Task OnGetAsync(string? q, int page = 1)
         {
             Q = q?.Trim();
             var isAdmin = User.IsInRole("assistant-admin");
+
+            var list = new List<ClientSummary>();
 
             if (isAdmin)
             {
                 if (!string.IsNullOrEmpty(Q))
                 {
                     var realms = await _realms.GetRealmsAsync();
-                    var list = new List<ClientSummary>();
                     foreach (var r in realms)
                     {
                         if (string.IsNullOrWhiteSpace(r.Realm)) continue;
@@ -49,15 +56,19 @@ namespace Assistant.Pages
                                 FlowService: false));
                         }
                     }
-                    Clients = list;
                 }
 
                 ShowEmptyMessage = !string.IsNullOrEmpty(Q);
-                return;
+            }
+            else
+            {
+                list = (await _provider.GetClientsForUser(User)).ToList();
+                ShowEmptyMessage = true;
             }
 
-            Clients = (await _provider.GetClientsForUser(User)).ToList();
-            ShowEmptyMessage = true;
+            TotalPages = Math.Max(1, (int)Math.Ceiling(list.Count / (double)PageSize));
+            PageNumber = Math.Clamp(page, 1, TotalPages);
+            Clients = list.Skip((PageNumber - 1) * PageSize).Take(PageSize).ToList();
         }
     }
 }


### PR DESCRIPTION
## Summary
- paginate clients on index page showing 20 per page
- provide navigation with previous/next links and page info

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c69e855350832dbd304cf7c583fd57