### PR TITLE
Add pagination to client list

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -168,6 +168,23 @@ else if (Model.Clients.Any())
             </a>
         }
     </div>
+
+    @if (Model.TotalPages > 1)
+    {
+        <div class="flex justify-center mt-6">
+            <nav class="flex items-center gap-2">
+                @if (Model.HasPreviousPage)
+                {
+                    <a asp-route-q="@Model.Q" asp-route-page="@(Model.PageNumber - 1)" class="btn-subtle">Previous</a>
+                }
+                <span class="text-sm text-slate-400">Page @Model.PageNumber of @Model.TotalPages</span>
+                @if (Model.HasNextPage)
+                {
+                    <a asp-route-q="@Model.Q" asp-route-page="@(Model.PageNumber + 1)" class="btn-subtle">Next</a>
+                }
+            </nav>
+        </div>
+    }
 }
 
 <script>


### PR DESCRIPTION
## Summary
- paginate clients on index page showing 20 per page
- provide navigation with previous/next links and page info
- fix page query binding for working pagination

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c69e855350832dbd304cf7c583fd57