### PR TITLE
Fix pagination parameter

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -175,12 +175,12 @@ else if (Model.Clients.Any())
             <nav class="flex items-center gap-2">
                 @if (Model.HasPreviousPage)
                 {
-                    <a asp-page="./Index" asp-route-q="@Model.Q" asp-route-page="@(Model.PageNumber - 1)" class="btn-subtle">Previous</a>
+                    <a asp-page="./Index" asp-route-q="@Model.Q" asp-route-pageNumber="@(Model.PageNumber - 1)" class="btn-subtle">Previous</a>
                 }
                 <span class="text-sm text-slate-400">Page @Model.PageNumber of @Model.TotalPages</span>
                 @if (Model.HasNextPage)
                 {
-                    <a asp-page="./Index" asp-route-q="@Model.Q" asp-route-page="@(Model.PageNumber + 1)" class="btn-subtle">Next</a>
+                    <a asp-page="./Index" asp-route-q="@Model.Q" asp-route-pageNumber="@(Model.PageNumber + 1)" class="btn-subtle">Next</a>
                 }
             </nav>
         </div>

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -29,7 +29,7 @@ namespace Assistant.Pages
         public bool HasPreviousPage => PageNumber > 1;
         public bool HasNextPage => PageNumber < TotalPages;
 
-        public async Task OnGetAsync(string? q, int page = 1)
+        public async Task OnGetAsync(string? q, int pageNumber = 1)
         {
             Q = q?.Trim();
             var isAdmin = User.IsInRole("assistant-admin");
@@ -67,7 +67,7 @@ namespace Assistant.Pages
             }
 
             TotalPages = Math.Max(1, (int)Math.Ceiling(list.Count / (double)PageSize));
-            PageNumber = Math.Clamp(page, 1, TotalPages);
+            PageNumber = Math.Clamp(pageNumber, 1, TotalPages);
             Clients = list.Skip((PageNumber - 1) * PageSize).Take(PageSize).ToList();
         }
     }


### PR DESCRIPTION
## Summary
- Rename pagination query parameter to avoid clashing with Razor Pages routing.
- Update navigation links to use the new parameter for proper page transitions.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68c6ab7794cc832db230d00c27322039