### PR TITLE
Handle full page requests for clients pagination

### DIFF
--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -112,10 +112,14 @@ namespace Assistant.Pages
             Clients = list.Skip((PageNumber - 1) * PageSize).Take(PageSize).ToList();
         }
 
-        public async Task<PartialViewResult> OnGetClientsAsync(string? q, int pageNumber = 1)
+        public async Task<IActionResult> OnGetClientsAsync(string? q, int pageNumber = 1)
         {
             await OnGetAsync(q, pageNumber);
-            return Partial("_ClientsList", this);
+            if (Request.Headers["X-Requested-With"] == "XMLHttpRequest")
+            {
+                return Partial("_ClientsList", this);
+            }
+            return Page();
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix client pagination handler to return full page when accessed directly

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b05345c0832dbe97f0a0c5510d65