### PR TITLE
Add favicon metadata and placeholder title

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@(ViewData["Title"] ?? "Keycloak Shell")</title>
+    <link rel="icon" type="image/x-icon" href="~/favicon.ico" />
+    <link rel="preload" href="~/favicon.ico" as="image" />
 
     <!-- Tailwind для прототипа -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/wwwroot/js/transitions.js
+++ b/wwwroot/js/transitions.js
@@ -1,5 +1,6 @@
 // Smooth page transitions
 const TRANSITION_MS = 300;
+const PLACEHOLDER_TITLE = 'Keycloak Shell';
 
 document.addEventListener('DOMContentLoaded', () => {
     // Fade in content on initial load
@@ -23,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const url = anchor.href;
             if (url && anchor.origin === window.location.origin) {
                 ev.preventDefault();
+                document.title = PLACEHOLDER_TITLE;
                 document.body.classList.remove('page-loaded');
                 setTimeout(() => {
                     window.location.href = url;


### PR DESCRIPTION
## Summary
- include favicon link and preload in layout
- set placeholder tab title during transitions to reduce URL flicker

## Testing
- `dotnet build` *(fails: NETSDK1045 – SDK doesn't support .NET 9)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bf74fab4832d979a913f05d9ea24