### PR TITLE
Keep page title and favicon static

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>@(ViewData["Title"] ?? "Keycloak Shell")</title>
+    <title>Assistant</title>
     <link rel="icon" type="image/x-icon" href="~/favicon.ico" />
     <link rel="preload" href="~/favicon.ico" as="image" />
 

--- a/wwwroot/js/transitions.js
+++ b/wwwroot/js/transitions.js
@@ -1,6 +1,5 @@
 // Smooth page transitions
 const TRANSITION_MS = 300;
-const PLACEHOLDER_TITLE = 'Keycloak Shell';
 
 document.addEventListener('DOMContentLoaded', () => {
     // Fade in content on initial load
@@ -24,7 +23,6 @@ document.addEventListener('DOMContentLoaded', () => {
             const url = anchor.href;
             if (url && anchor.origin === window.location.origin) {
                 ev.preventDefault();
-                document.title = PLACEHOLDER_TITLE;
                 document.body.classList.remove('page-loaded');
                 setTimeout(() => {
                     window.location.href = url;


### PR DESCRIPTION
## Summary
- Fix shared layout to use fixed title and favicon
- Drop placeholder title changes in transitions script

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c53ba2a8832d8cbf5514877a0a7d