### PR TITLE
Skip service role lookup when client lacks service account

### DIFF
--- a/KeyCloak/ClientsService.cs
+++ b/KeyCloak/ClientsService.cs
@@ -202,7 +202,9 @@ namespace Assistant.KeyCloak
                 return null;
 
             var localRoles = await GetClientRolesAsync(realm, rep.Id!, 0, 1000, null, ct);
-            var svcRoles = await GetServiceAccountRolesAsync(realm, rep.Id!, ct);
+            var svcRoles = (rep.ServiceAccountsEnabled ?? false)
+                ? await GetServiceAccountRolesAsync(realm, rep.Id!, ct)
+                : new List<(string ClientId, string Role)>();
 
             return new ClientDetails(
                 rep.Id!,


### PR DESCRIPTION
## Summary
- avoid calling Keycloak service-account APIs when client has service accounts disabled

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d2a85cfc832da6f06d8b60598bcf