### PR TITLE
Display client default scopes

### DIFF
--- a/KeyCloak/ClientsService.cs
+++ b/KeyCloak/ClientsService.cs
@@ -20,7 +20,8 @@ namespace Assistant.KeyCloak
         bool ServiceAccount,
         List<string> RedirectUris,
         List<string> LocalRoles,
-        List<(string ClientId, string Role)> ServiceRoles
+        List<(string ClientId, string Role)> ServiceRoles,
+        List<string> DefaultScopes
     );
 
     // Ответы KC (берём только нужные поля)
@@ -39,6 +40,7 @@ namespace Assistant.KeyCloak
         public bool? StandardFlowEnabled { get; set; }
         public bool? ServiceAccountsEnabled { get; set; }
         public List<string>? RedirectUris { get; set; }
+        public List<string>? DefaultClientScopes { get; set; }
     }
     internal sealed class RoleRep
     {
@@ -205,6 +207,7 @@ namespace Assistant.KeyCloak
             var svcRoles = (rep.ServiceAccountsEnabled ?? false)
                 ? await GetServiceAccountRolesAsync(realm, rep.Id!, ct)
                 : new List<(string ClientId, string Role)>();
+            var defaultScopes = rep.DefaultClientScopes?.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s!).ToList() ?? new();
 
             return new ClientDetails(
                 rep.Id!,
@@ -216,7 +219,8 @@ namespace Assistant.KeyCloak
                 rep.ServiceAccountsEnabled ?? false,
                 rep.RedirectUris?.Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r!).ToList() ?? new(),
                 localRoles,
-                svcRoles
+                svcRoles,
+                defaultScopes
             );
         }
 

--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -167,7 +167,7 @@
     <div class="tab-pane hidden" data-tab="Scopes" role="tabpanel">
         <div class="kc-card p-5 kc-hover">
             <div class="text-slate-200 font-semibold mb-3">Default scopes</div>
-            <div class="kc-th mb-2">Список скопов по умолчанию (заглушка).</div>
+            <div class="kc-th mb-2">Список скопов по умолчанию.</div>
             <div id="scopesList" class="flex flex-wrap gap-2"></div>
         </div>
     </div>
@@ -399,6 +399,7 @@
           const redirs   = JSON.parse('@Html.Raw(Model.RedirectUrisJson)');
           const locals   = JSON.parse('@Html.Raw(Model.LocalRolesJson)');
           const svcRoles = JSON.parse('@Html.Raw(Model.ServiceRolesJson)');
+          const scopes   = JSON.parse('@Html.Raw(Model.DefaultScopesJson)');
 
           // Redirect URIs
           const swStandard = document.getElementById('swStandard');
@@ -415,6 +416,15 @@
               chip.className = 'kc-chip';
               chip.innerHTML = `${v} <button type="button" title="Remove">×</button>`;
               chip.querySelector('button').addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(el, arr); });
+              el.appendChild(chip);
+            });
+          }
+          function renderStaticChips(el, arr){
+            el.innerHTML = '';
+            arr.forEach(v =>{
+              const chip = document.createElement('span');
+              chip.className = 'kc-chip';
+              chip.textContent = v;
               el.appendChild(chip);
             });
           }
@@ -469,6 +479,10 @@
             const c = svcClient.value, r = svcRole.value; if (!c || !r) return;
             const v = `${c}: ${r}`; svcRoles.push(v); renderChips(svcList, svcRoles);
           });
+
+          // Default scopes
+          const scopesList = document.getElementById('scopesList');
+          renderStaticChips(scopesList, scopes);
 
           // ---------- Events (ленивая инициализация) ----------
           window.initEvents = function(){

--- a/Pages/Clients/Details.cshtml.cs
+++ b/Pages/Clients/Details.cshtml.cs
@@ -25,6 +25,7 @@ namespace Assistant.Pages.Clients
         public string RedirectUrisJson { get; private set; } = "[]";
         public string LocalRolesJson { get; private set; } = "[]";
         public string ServiceRolesJson { get; private set; } = "[]";
+        public string DefaultScopesJson { get; private set; } = "[]";
 
         public async Task<IActionResult> OnGetAsync(CancellationToken ct)
         {
@@ -48,6 +49,7 @@ namespace Assistant.Pages.Clients
             RedirectUrisJson = JsonSerializer.Serialize(details.RedirectUris);
             LocalRolesJson = JsonSerializer.Serialize(details.LocalRoles);
             ServiceRolesJson = JsonSerializer.Serialize(details.ServiceRoles.Select(p => $"{p.ClientId}: {p.Role}"));
+            DefaultScopesJson = JsonSerializer.Serialize(details.DefaultScopes);
 
             return Page();
         }


### PR DESCRIPTION
## Summary
- show client's default scopes in the details page
- parse default scopes from Keycloak client details

## Testing
- `~/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68c71a5dc244832dbb16fb96ca6d014a