### PR TITLE
Disable service account when client auth is off

### DIFF
--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -439,6 +439,28 @@
           const locals   = JSON.parse('@Html.Raw(Model.LocalRolesJson)');
           @* const scopes   = JSON.parse('@Html.Raw(Model.DefaultScopesJson)'); *@
 
+          const swClientAuth = document.getElementById('swClientAuth');
+          const swService    = document.getElementById('swService');
+          const tabServiceRoles = document.querySelector('.tab-btn[data-tab="ServiceRoles"]');
+
+          function updateServiceRolesTab(){
+            const on = swService?.checked;
+            tabServiceRoles?.classList.toggle('kc-disabled', !on);
+            const active = document.querySelector('.tab-btn.active')?.dataset.tab;
+            if (!on && active === 'ServiceRoles') showTab('Overview');
+          }
+
+          function updateServiceState(){
+            const authOn = swClientAuth?.checked;
+            if (!authOn && swService){ swService.checked = false; }
+            if (swService) swService.disabled = !authOn;
+            updateServiceRolesTab();
+          }
+
+          swClientAuth?.addEventListener('change', updateServiceState);
+          swService?.addEventListener('change', updateServiceRolesTab);
+          updateServiceState();
+
           // Redirect URIs
           const swStandard = document.getElementById('swStandard');
           const redirectPanel = document.getElementById('redirectPanel');


### PR DESCRIPTION
## Summary
- auto-disable service account when client authentication is turned off
- deactivate Service Roles tab if service account is disabled

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e4e4dbfc832da1c8a7ca2dcbfa61