### PR TITLE
Ensure toast notifications stick to top-right corner

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -278,26 +278,26 @@
                 </div>
             </div>
         </form>
-
-        @if (!ViewContext.ViewData.ModelState.IsValid)
-        {
-            <div class="kc-toast kc-toast-error" id="formErrorToast" role="alert">
-                <div class="kc-toast-icon">!</div>
-                <div class="kc-toast-body">
-                    <div class="kc-toast-title">Не удалось создать клиента</div>
-                    <div asp-validation-summary="All" class="validation-summary-errors"></div>
-                </div>
-                <button type="button" class="kc-toast-close" aria-label="Закрыть"
-                        onclick="this.closest('.kc-toast').remove()">
-                    ×
-                </button>
-            </div>
-            <script>
-                setTimeout(() => document.getElementById('formErrorToast')?.remove(), 10000);
-            </script>
-        }
     </div>
 </div>
+
+@section Toasts {
+    @if (!ViewContext.ViewData.ModelState.IsValid)
+    {
+        <div class="kc-toast kc-toast-error" id="formErrorToast" role="alert">
+            <div class="kc-toast-icon">!</div>
+            <div class="kc-toast-body">
+                <div class="kc-toast-title">Не удалось создать клиента</div>
+                <div asp-validation-summary="All" class="validation-summary-errors"></div>
+            </div>
+            <button type="button" class="kc-toast-close" aria-label="Закрыть"
+                    onclick="this.closest('.kc-toast').remove()">×</button>
+        </div>
+        <script>
+            setTimeout(() => document.getElementById('formErrorToast')?.remove(), 10000);
+        </script>
+    }
+}
 
 @section Scripts
 {

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -47,20 +47,6 @@
         </div>
     </div>
 </div>
-
-@if (TempData["FlashOk"] is string flash)
-{
-    <div class="kc-toast kc-toast-success" id="flashToast" role="alert">
-        <div class="kc-toast-icon">✓</div>
-        <div class="kc-toast-body">
-            <div class="kc-toast-title">@flash</div>
-        </div>
-        <button type="button" class="kc-toast-close" aria-label="Закрыть"
-                onclick="this.closest('.kc-toast').remove()">×</button>
-    </div>
-    <script>setTimeout(() => document.getElementById('flashToast')?.remove(), 10000);</script>
-}
-
 <div id="clientsContainer">
     @await Html.PartialAsync("_ClientsList", Model)
 </div>
@@ -108,3 +94,18 @@
         attach();
     })();
 </script>
+
+@section Toasts {
+    @if (TempData["FlashOk"] is string flash)
+    {
+        <div class="kc-toast kc-toast-success" id="flashToast" role="alert">
+            <div class="kc-toast-icon">✓</div>
+            <div class="kc-toast-body">
+                <div class="kc-toast-title">@flash</div>
+            </div>
+            <button type="button" class="kc-toast-close" aria-label="Закрыть"
+                    onclick="this.closest('.kc-toast').remove()">×</button>
+        </div>
+        <script>setTimeout(() => document.getElementById('flashToast')?.remove(), 10000);</script>
+    }
+}

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -32,6 +32,7 @@
     <main id="app" class="container mx-auto px-4 md:px-6 py-6">
         @RenderBody()
     </main>
+    @RenderSection("Toasts", required: false)
     <div id="globalSpinner" class="fixed inset-0 bg-slate-900/40 flex items-center justify-center z-50 hidden">
         <div class="w-16 h-16 border-4 border-slate-300 border-t-transparent rounded-full animate-spin"></div>
     </div>


### PR DESCRIPTION
## Summary
- Render toast sections outside main app container to avoid centering shifts
- Move success and error toast markup into dedicated `Toasts` section

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c80c596390832db5189ee33aff35f3