### PR TITLE
Add event filtering for client details

### DIFF
--- a/KeyCloak/EventsService.cs
+++ b/KeyCloak/EventsService.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Assistant.KeyCloak
+{
+    public sealed record EventEntry(string Type, DateTime At, string? User, string? Ip);
+
+    internal sealed class EventRep
+    {
+        public string? Type { get; set; }
+        public long? Time { get; set; }
+        public string? ClientId { get; set; }
+        public string? UserId { get; set; }
+        public string? Username { get; set; }
+        public string? IpAddress { get; set; }
+    }
+
+    internal sealed class EventConfigRep
+    {
+        public List<string>? EnabledEventTypes { get; set; }
+    }
+
+    public class EventsService
+    {
+        private readonly IHttpClientFactory _factory;
+        private readonly AdminApiOptions _opt;
+
+        public EventsService(IHttpClientFactory factory, IOptions<AdminApiOptions> opt)
+        {
+            _factory = factory;
+            _opt = opt.Value;
+        }
+
+        private string BaseUrl => _opt.BaseUrl.TrimEnd('/');
+
+        public async Task<List<string>> GetEventTypesAsync(string realm, CancellationToken ct = default)
+        {
+            var http = _factory.CreateClient("kc-admin");
+            var urlNew = $"{BaseUrl}/admin/realms/{Uri.EscapeDataString(realm)}/events/config";
+            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{Uri.EscapeDataString(realm)}/events/config";
+            using var resp = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
+            EnsureAuthOrThrow(resp);
+            var cfg = await resp.Content.ReadFromJsonAsync<EventConfigRep>(cancellationToken: ct);
+            return cfg?.EnabledEventTypes ?? new List<string>();
+        }
+
+        public async Task<List<EventEntry>> GetEventsAsync(string realm, string clientId, string? type,
+            DateTime? from, DateTime? to, string? user, string? ip, int max = 50, CancellationToken ct = default)
+        {
+            var http = _factory.CreateClient("kc-admin");
+            var qs = new List<string> { $"client={Uri.EscapeDataString(clientId)}", $"max={max}", "first=0" };
+            if (!string.IsNullOrWhiteSpace(type)) qs.Add($"type={Uri.EscapeDataString(type)}");
+            if (!string.IsNullOrWhiteSpace(user)) qs.Add($"user={Uri.EscapeDataString(user)}");
+            if (!string.IsNullOrWhiteSpace(ip)) qs.Add($"ipAddress={Uri.EscapeDataString(ip)}");
+            if (from.HasValue) qs.Add($"dateFrom={new DateTimeOffset(from.Value).ToUnixTimeMilliseconds()}");
+            if (to.HasValue) qs.Add($"dateTo={new DateTimeOffset(to.Value).ToUnixTimeMilliseconds()}");
+            var query = string.Join('&', qs);
+            var urlNew = $"{BaseUrl}/admin/realms/{Uri.EscapeDataString(realm)}/events?{query}";
+            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{Uri.EscapeDataString(realm)}/events?{query}";
+            using var resp = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
+            EnsureAuthOrThrow(resp);
+            var reps = await resp.Content.ReadFromJsonAsync<List<EventRep>>(cancellationToken: ct) ?? new();
+            return reps
+                .Where(r => string.Equals(r.ClientId, clientId, StringComparison.OrdinalIgnoreCase))
+                .Select(r => new EventEntry(
+                    r.Type ?? string.Empty,
+                    DateTimeOffset.FromUnixTimeMilliseconds(r.Time ?? 0).LocalDateTime,
+                    r.Username ?? r.UserId,
+                    r.IpAddress))
+                .ToList();
+        }
+
+        private static async Task<HttpResponseMessage> GetAsyncWithFallback(HttpClient http, string newUrl, string legacyUrl, CancellationToken ct)
+        {
+            var resp = await http.GetAsync(newUrl, ct);
+            if (resp.StatusCode == HttpStatusCode.NotFound)
+            {
+                resp.Dispose();
+                resp = await http.GetAsync(legacyUrl, ct);
+            }
+            return resp;
+        }
+
+        private static void EnsureAuthOrThrow(HttpResponseMessage resp)
+        {
+            if (resp.StatusCode == HttpStatusCode.Forbidden)
+                throw new UnauthorizedAccessException("Недостаточно прав для операции (нужны права realm-management).");
+            if (resp.StatusCode == HttpStatusCode.BadRequest)
+            {
+                var body = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                throw new InvalidOperationException($"Запрос отклонён (400). Детали: {body}");
+            }
+            resp.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -596,8 +596,6 @@
           // ---------- Events (ленивая инициализация) ----------
           window.initEvents = function(){
             const pageSize = 10;
-            const TYPES = ["CLIENT_CREATED","CLIENT_UPDATED","ROLE_ADDED","ROLE_REMOVED","SCOPE_ASSIGNED","LOGIN","LOGOUT","TOKEN_EXCHANGED"];
-            const USERS = ["alice","bob","charlie","svc-deploy","svc-ci","admin"];
             const rowsEl  = document.getElementById('eventsRows');
             const pagerEl = document.getElementById('eventsPager');
             const selType = document.getElementById('evFilterType');
@@ -606,54 +604,39 @@
             const inUser  = document.getElementById('evUser');
             const inIp    = document.getElementById('evIp');
 
-            const rand = n => Math.floor(Math.random()*n);
-            function gen(n=40){
-              const now = Date.now(), arr=[];
-              for (let i=0;i<n;i++){
-                const minsBack = rand(60*24*7);
-                const at = new Date(now - minsBack*60000);
-                const ip = `10.${rand(255)}.${rand(255)}.${1+rand(254)}`;
-                arr.push({ type:TYPES[rand(TYPES.length)], at, user:USERS[rand(USERS.length)], ip });
-              }
-              return arr.sort((a,b)=> b.at - a.at);
-            }
-            const all = gen(40);
-            Array.from(new Set(all.map(e=>e.type))).forEach(t=> selType.add(new Option(t,t)));
+            const types = JSON.parse('@Html.Raw(Model.EventTypesJson)');
+            types.forEach(t=> selType.add(new Option(t,t)));
 
+            let all = [];
             let page = 1;
-            const fmt = d => d.toLocaleString();
+            const fmt = s => new Date(s).toLocaleString();
 
-            function applyFilters(data){
-              const t  = selType.value;
-              const uf = (inUser.value||'').trim().toLowerCase();
-              const ip = (inIp.value||'').trim();
-              const df = inFrom.value ? new Date(inFrom.value) : null;
-              const dt = inTo.value   ? new Date(inTo.value)   : null;
-
-              return data.filter(e=>{
-                if (t && e.type !== t) return false;
-                if (uf && !e.user.toLowerCase().includes(uf)) return false;
-                if (ip && !e.ip.includes(ip)) return false;
-                if (df && e.at < df) return false;
-                if (dt && e.at > new Date(dt.getTime() + 24*3600*1000 - 1)) return false;
-                return true;
-              });
+            async function load(){
+              const params = new URLSearchParams({ realm, clientId });
+              if (selType.value) params.set('type', selType.value);
+              if (inFrom.value) params.set('from', inFrom.value);
+              if (inTo.value) params.set('to', inTo.value);
+              if ((inUser.value||'').trim()) params.set('user', inUser.value.trim());
+              if ((inIp.value||'').trim()) params.set('ip', inIp.value.trim());
+              const url = `${PAGE_URL}?handler=Events&${params.toString()}`;
+              try { all = await fetchJson(url); } catch { all = []; }
+              page = 1;
+              render();
             }
 
             function render(){
-              const data = applyFilters(all);
-              const totalPages = Math.max(1, Math.ceil(data.length / pageSize));
+              const totalPages = Math.max(1, Math.ceil(all.length / pageSize));
               if (page > totalPages) page = totalPages;
 
               rowsEl.innerHTML = '';
-              const slice = data.slice((page-1)*pageSize, page*pageSize);
+              const slice = all.slice((page-1)*pageSize, page*pageSize);
               slice.forEach(e=>{
                 rowsEl.insertAdjacentHTML('beforeend', `
                   <div class="grid grid-cols-12 gap-2 text-sm py-2 border-b border-white/5 px-1">
                     <div class="col-span-3 text-slate-200">${e.type}</div>
                     <div class="col-span-3 text-slate-300">${fmt(e.at)}</div>
-                    <div class="col-span-3 text-slate-300">${e.user}</div>
-                    <div class="col-span-3 text-slate-400">${e.ip}</div>
+                    <div class="col-span-3 text-slate-300">${e.user||''}</div>
+                    <div class="col-span-3 text-slate-400">${e.ip||''}</div>
                   </div>
                 `);
               });
@@ -661,26 +644,24 @@
               pagerEl.innerHTML = '';
               if (totalPages > 1){
                 const mk = (label,target,disabled=false,active=false)=>
-                  `<a class="rounded-lg px-3 py-1 text-sm border border-white/10 ${active?'bg-white/10 text-white':(disabled?'pointer-events-none opacity-50':'bg-white/5 hover:bg-white/10')}"
-                      href="#tab=Events" data-page="${target}">${label}</a>`;
+                  `<a class="rounded-lg px-3 py-1 text-sm border border-white/10 ${active?'bg-white/10 text-white':(disabled?'pointer-events-none opacity-50':'bg-white/5 hover:bg-white/10')}" href="#tab=Events" data-page="${target}">${label}</a>`;
                 const inner = [
                   mk('Prev', Math.max(1,page-1), page===1),
                   ...Array.from({length: totalPages}, (_,i)=> mk(String(i+1), i+1, false, i+1===page)),
                   mk('Next', Math.min(totalPages,page+1), page===totalPages)
                 ].join('');
                 pagerEl.insertAdjacentHTML('beforeend', `<div class="flex items-center justify-center gap-1 mt-4">${inner}</div>`);
-                pagerEl.querySelectorAll('a[data-page]').forEach(a => a.addEventListener('click', (ev)=>{ ev.preventDefault(); page = parseInt(a.dataset.page,10); render(); }));
+                pagerEl.querySelectorAll('a[data-page]').forEach(a => a.addEventListener('click', ev=>{ ev.preventDefault(); page = parseInt(a.dataset.page,10); render(); }));
               }
             }
 
             [selType, inFrom, inTo, inUser, inIp].forEach(el=>{
-              el?.addEventListener('input', ()=>{ page=1; render(); });
-              el?.addEventListener('change', ()=>{ page=1; render(); });
+              el?.addEventListener('input', load);
+              el?.addEventListener('change', load);
             });
 
-            render();
+            load();
           };
-
           // ---------- Сбор данных перед Save ----------
           const saveForm = document.getElementById('saveForm');
           const btnDelete = document.getElementById('btnDelete');

--- a/Program.cs
+++ b/Program.cs
@@ -33,6 +33,7 @@ builder.Services.AddHttpClient("kc-admin", (sp, c) =>
 
 builder.Services.AddScoped<Assistant.KeyCloak.RealmsService>();
 builder.Services.AddScoped<Assistant.KeyCloak.ClientsService>();
+builder.Services.AddScoped<Assistant.KeyCloak.EventsService>();
 builder.Services.AddSingleton<UserClientsRepository>();
 builder.Services.AddScoped<IClientsProvider, DbClientsProvider>();
 builder.Services.AddAuthorization();


### PR DESCRIPTION
## Summary
- add EventsService to query Keycloak event types and client events
- wire events tab to fetch and filter events by type, date range, user and IP
- register EventsService in DI container

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c81fb9b624832d92f62494c575c84a