### PR TITLE
Fix Events search button

### DIFF
--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -631,6 +631,7 @@
             document.addEventListener('click', e=>{ if(!ddType) return; if(e.target!==inType && !ddType.contains(e.target)) ddType.classList.add('hidden'); });
 
             [inType,inFrom,inTo,inUser,inIp].forEach(el=> el?.addEventListener('keydown', ev=>{ if(ev.key==='Enter'){ ev.preventDefault(); load(); }}));
+            btnSearch?.addEventListener('click', load);
 
             let all = [];
             let page = 1;


### PR DESCRIPTION
## Summary
- invoke backend search when clicking Events search button

## Testing
- `~/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68c82e8a18a4832da587f9531c66b81d