### PR TITLE
Adjust events filter layout

### DIFF
--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -377,16 +377,16 @@
                 <div class="text-xs text-slate-400">Created: @(DateTime.Now.AddDays(-5).ToString("g")) by admin</div>
             </div>
 
-            <div class="grid gap-2 mb-10 md:flex md:flex-wrap md:items-center md:gap-3">
-                <div class="relative w-full md:w-56 md:max-w-xs md:flex-none">
+            <div class="event-filters grid gap-2 mb-10">
+                <div class="relative w-full">
                     <input id="evFilterType" class="kc-input kc-select rounded-xl px-3 py-2 text-xs w-full" placeholder="All types" autocomplete="off" />
                     <div id="evTypeDd" class="absolute z-20 mt-1 w-full kc-card p-2 hidden text-xs"></div>
                 </div>
-                <input id="evFrom" type="datetime-local" class="kc-input rounded-xl px-3 py-1.5 text-xs w-full md:w-44 md:flex-none" />
-                <input id="evTo" type="datetime-local" class="kc-input rounded-xl px-3 py-1.5 text-xs w-full md:w-44 md:flex-none" />
-                <input id="evUser" placeholder="User" class="kc-input rounded-xl px-3 py-1.5 text-xs w-full md:w-40 md:flex-none" />
-                <input id="evIp" placeholder="IP адрес" class="kc-input rounded-xl px-3 py-1.5 text-xs w-full md:w-32 md:flex-none" />
-                <button id="evSearchBtn" type="button" class="btn-subtle md:self-center md:flex-none">Search</button>
+                <input id="evFrom" type="datetime-local" class="kc-input rounded-xl px-3 py-1.5 text-xs w-full" />
+                <input id="evTo" type="datetime-local" class="kc-input rounded-xl px-3 py-1.5 text-xs w-full" />
+                <input id="evUser" placeholder="User" class="kc-input rounded-xl px-3 py-1.5 text-xs w-full" />
+                <input id="evIp" placeholder="IP адрес" class="kc-input rounded-xl px-3 py-1.5 text-xs w-full" />
+                <button id="evSearchBtn" type="button" class="btn-subtle w-full h-full">Search</button>
             </div>
 
             <div class="grid grid-cols-12 gap-2 kc-th px-1 text-center">

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -493,3 +493,22 @@ body.page-loaded #app {
     transform: translateY(0);
 }
 
+/* ===== Events filters ===== */
+.event-filters {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    align-items: stretch;
+}
+
+.event-filters > * {
+    width: 100%;
+    min-width: 0;
+}
+
+@media (min-width: 768px) {
+    .event-filters {
+        grid-template-columns: 1.5fr repeat(5, minmax(0, 1fr));
+    }
+}
+


### PR DESCRIPTION
## Summary
- expand the Events tab filter controls to fill the card width with a consistent layout
- add CSS grid styling so all controls share the same size while keeping the type selector wider

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8434dc9cc832da5902698d5a0a4e8