### PR TITLE
Keep client secret hidden when copying

### DIFF
--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -565,8 +565,6 @@
             const resp = await fetch(`/api/client-secret?realm=${encodeURIComponent(realm)}&clientId=${encodeURIComponent(clientId)}`, { method });
             if (resp.ok) {
               const data = await resp.json();
-              const input = document.getElementById('credSecret');
-              if (input) input.value = data.secret || '';
               return data.secret || '';
             }
             return '';
@@ -582,7 +580,8 @@
               btnShowSecret.title = 'Показать';
               btnShowSecret.setAttribute('aria-label','Показать');
             } else {
-              await fetchSecret('GET');
+              const secret = await fetchSecret('GET');
+              input.value = secret;
               secretVisible = true;
               btnShowSecret.title = 'Скрыть';
               btnShowSecret.setAttribute('aria-label','Скрыть');
@@ -590,16 +589,23 @@
           });
 
           document.getElementById('btnCopySecret')?.addEventListener('click', async () => {
-            const secret = await fetchSecret('GET');
-            secretVisible = true;
-            btnShowSecret && (btnShowSecret.title = 'Скрыть', btnShowSecret.setAttribute('aria-label','Скрыть'));
+            const secret = secretVisible
+              ? (document.getElementById('credSecret')?.value || '')
+              : await fetchSecret('GET');
+            const input = document.getElementById('credSecret');
+            if (input && !secretVisible) input.value = secretMask;
+            if (!secretVisible) {
+              btnShowSecret && (btnShowSecret.title = 'Показать', btnShowSecret.setAttribute('aria-label','Показать'));
+            }
             try { await navigator.clipboard.writeText(secret); } catch {}
           });
 
-          document.getElementById('btnRegenSecret')?.addEventListener('click', () => {
+          document.getElementById('btnRegenSecret')?.addEventListener('click', async () => {
+            const secret = await fetchSecret('POST');
+            const input = document.getElementById('credSecret');
+            if (input) input.value = secret;
             secretVisible = true;
             btnShowSecret && (btnShowSecret.title = 'Скрыть', btnShowSecret.setAttribute('aria-label','Скрыть'));
-            fetchSecret('POST');
           });
 
           // ---------- Events (ленивая инициализация) ----------


### PR DESCRIPTION
## Summary
- avoid updating the secret field when fetching for clipboard operations so the mask remains
- update the show and regenerate handlers to manage the input value explicitly
- keep the "show" control state consistent when copying a hidden secret

## Testing
- ⚠️ `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d23f3d84832db0c42050c7df15d3