### PR TITLE
Add toast notifications for client updates

### DIFF
--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -414,6 +414,31 @@
 
 <form method="post" id="deleteForm" asp-page-handler="Delete" asp-route-realm="@realm" asp-route-clientId="@clientId" class="hidden"></form>
 
+@section Toasts {
+    @if (TempData["FlashOk"] is string ok)
+    {
+        <div class="kc-toast kc-toast-success" id="flashToastOk" role="alert">
+            <div class="kc-toast-icon">✓</div>
+            <div class="kc-toast-body">
+                <div class="kc-toast-title">@ok</div>
+            </div>
+            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
+        </div>
+        <script>setTimeout(() => document.getElementById('flashToastOk')?.remove(), 10000);</script>
+    }
+    @if (TempData["FlashError"] is string err)
+    {
+        <div class="kc-toast kc-toast-error" id="flashToastError" role="alert">
+            <div class="kc-toast-icon">!</div>
+            <div class="kc-toast-body">
+                <div class="kc-toast-title">@err</div>
+            </div>
+            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
+        </div>
+        <script>setTimeout(() => document.getElementById('flashToastError')?.remove(), 10000);</script>
+    }
+}
+
 @section Scripts {
     <script>
         const svcRoles = JSON.parse('@Html.Raw(Model.ServiceRolesJson)');

--- a/Pages/Clients/Details.cshtml.cs
+++ b/Pages/Clients/Details.cshtml.cs
@@ -99,8 +99,17 @@ namespace Assistant.Pages.Clients
                 svc
             );
 
-            await _clients.UpdateClientAsync(spec, ct);
-            TempData["Flash"] = "Changes saved.";
+            try
+            {
+                await _clients.UpdateClientAsync(spec, ct);
+            }
+            catch (Exception ex)
+            {
+                TempData["FlashError"] = $"Не удалось обновить клиента: {ex.Message}";
+                return RedirectToPage(new { realm = Realm, clientId = ClientId });
+            }
+
+            TempData["FlashOk"] = "Клиент успешно обновлён.";
             return RedirectToPage(new { realm = Realm, clientId = newId });
         }
 


### PR DESCRIPTION
## Summary
- display toast notifications on the client details page for successful updates and errors
- surface backend update failures as toast errors while preserving success confirmation messaging

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8e1ffe24832d97a1a92abd12dc34