### PR TITLE
Add audit logging for Keycloak client operations

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -21,6 +21,7 @@ builder.Services.Configure<Assistant.KeyCloak.AdminApiOptions>(
     builder.Configuration.GetSection("KeycloakAdmin"));
 
 builder.Services.AddMemoryCache();
+builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddSingleton<Assistant.KeyCloak.IAdminTokenProvider, Assistant.KeyCloak.AdminTokenProvider>();
 builder.Services.AddTransient<Assistant.KeyCloak.AdminBearerHandler>();
@@ -125,30 +126,18 @@ app.MapGet("/api/client-secret", async (
     string realm,
     string clientId,
     ClientsService clients,
-    ApiLogRepository logs,
-    ClaimsPrincipal user,
     CancellationToken ct) =>
 {
     var secret = await clients.GetClientSecretAsync(realm, clientId, ct);
-    var username = user.Identity?.Name;
-    if (string.IsNullOrWhiteSpace(username))
-        username = "unknown";
-    await logs.LogAsync("client-secret:get", username, realm, clientId, ct);
     return secret is not null ? Results.Ok(new { secret }) : Results.NotFound();
 }).RequireAuthorization();
 app.MapPost("/api/client-secret", async (
     string realm,
     string clientId,
     ClientsService clients,
-    ApiLogRepository logs,
-    ClaimsPrincipal user,
     CancellationToken ct) =>
 {
     var secret = await clients.RegenerateClientSecretAsync(realm, clientId, ct);
-    var username = user.Identity?.Name;
-    if (string.IsNullOrWhiteSpace(username))
-        username = "unknown";
-    await logs.LogAsync("client-secret:regenerate", username, realm, clientId, ct);
     return secret is not null ? Results.Ok(new { secret }) : Results.NotFound();
 }).RequireAuthorization();
 app.MapRazorPages().WithStaticAssets();


### PR DESCRIPTION
## Summary
- add HttpContext accessor support to enable contextual audit logging
- extend ClientsService to capture audit records for all Keycloak Admin API interactions
- rely on service-level logging for client secret endpoints instead of duplicating logs in Program

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caa2a3e418832d84ad08053edbfec9