### PR TITLE
Make client ID field read-only in overview

### DIFF
--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -89,7 +89,7 @@
                 <div class="space-y-3 justify-self-center w-full">
                     <div class="form-row_small">
                         <label class="text-sm text-slate-400">Client ID</label>
-                        <input id="ovClientId" class="kc-input rounded-xl px-3 py-2 text-sm" value="@clientId" />
+                        <input id="ovClientId" class="kc-input rounded-xl px-3 py-2 text-sm" value="@clientId" readonly />
                     </div>
                     <div class="form-row_small">
                         <label class="text-sm text-slate-400">Описание клиента</label>


### PR DESCRIPTION
## Summary
- add a read-only attribute to the Client ID input on the client details overview tab so the value is visible but not editable

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caa9fd6250832dac0480b19fa65d16