### PR TITLE
Fix redirect after client ID update

### DIFF
--- a/Pages/Clients/Details.cshtml.cs
+++ b/Pages/Clients/Details.cshtml.cs
@@ -106,11 +106,13 @@ namespace Assistant.Pages.Clients
             catch (Exception ex)
             {
                 TempData["FlashError"] = $"Не удалось обновить клиента: {ex.Message}";
-                return RedirectToPage(new { realm = Realm, clientId = ClientId });
+                return RedirectToPage("/Clients/Details", pageHandler: null,
+                    values: new { realm = Realm, clientId = ClientId });
             }
 
             TempData["FlashOk"] = "Клиент успешно обновлён.";
-            return RedirectToPage(new { realm = Realm, clientId = newId });
+            return RedirectToPage("/Clients/Details", pageHandler: null,
+                values: new { realm = Realm, clientId = newId });
         }
 
         public async Task<IActionResult> OnPostDeleteAsync(CancellationToken ct)


### PR DESCRIPTION
## Summary
- ensure saving client changes redirects back to the details page handler correctly to avoid 404 after renaming

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caac3c2a40832d80f5ed16fb88324c