### PR TITLE
Fix RedirectToPage parameter usage

### DIFF
--- a/Pages/Clients/Details.cshtml.cs
+++ b/Pages/Clients/Details.cshtml.cs
@@ -107,12 +107,12 @@ namespace Assistant.Pages.Clients
             {
                 TempData["FlashError"] = $"Не удалось обновить клиента: {ex.Message}";
                 return RedirectToPage("/Clients/Details", pageHandler: null,
-                    values: new { realm = Realm, clientId = ClientId });
+                    routeValues: new { realm = Realm, clientId = ClientId });
             }
 
             TempData["FlashOk"] = "Клиент успешно обновлён.";
             return RedirectToPage("/Clients/Details", pageHandler: null,
-                values: new { realm = Realm, clientId = newId });
+                routeValues: new { realm = Realm, clientId = newId });
         }
 
         public async Task<IActionResult> OnPostDeleteAsync(CancellationToken ct)


### PR DESCRIPTION
## Summary
- correct RedirectToPage calls in the clients details page to use the routeValues argument name

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caae191c24832daa55e1bd0f316feb