### PR TITLE
Update stored client references after client ID change

### DIFF
--- a/Pages/Clients/Details.cshtml.cs
+++ b/Pages/Clients/Details.cshtml.cs
@@ -102,6 +102,8 @@ namespace Assistant.Pages.Clients
             try
             {
                 await _clients.UpdateClientAsync(spec, ct);
+                await _repo.UpdateClientAsync(Realm!, ClientId!, newId, Enabled, StandardFlow, ServiceAccount, ct);
+                ClientId = newId;
             }
             catch (Exception ex)
             {

--- a/Services/UserClientsRepository.cs
+++ b/Services/UserClientsRepository.cs
@@ -77,6 +77,37 @@ public class UserClientsRepository
         await cmd.ExecuteNonQueryAsync(ct);
     }
 
+    public async Task UpdateClientAsync(
+        string realm,
+        string currentClientId,
+        string newClientId,
+        bool enabled,
+        bool flowStandard,
+        bool flowService,
+        CancellationToken ct = default)
+    {
+        await EnsureCreatedAsync(ct);
+
+        await using var conn = new NpgsqlConnection(_connString);
+        await conn.OpenAsync(ct);
+
+        var cmd = new NpgsqlCommand(@"update user_clients
+                set client_id = @newCid,
+                    enabled = @en,
+                    flow_standard = @std,
+                    flow_service = @svc
+                where client_id = @oldCid and realm = @realm;", conn);
+
+        cmd.Parameters.AddWithValue("newCid", newClientId);
+        cmd.Parameters.AddWithValue("en", enabled);
+        cmd.Parameters.AddWithValue("std", flowStandard);
+        cmd.Parameters.AddWithValue("svc", flowService);
+        cmd.Parameters.AddWithValue("oldCid", currentClientId);
+        cmd.Parameters.AddWithValue("realm", realm);
+
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
     public async Task<List<ClientSummary>> GetForUserAsync(string username, bool isAdmin, CancellationToken ct = default)
     {
         await EnsureCreatedAsync(ct);


### PR DESCRIPTION
## Summary
- add repository support for updating stored client references when a client ID changes
- update the client details save handler to persist the new client ID in the local storage after successful Keycloak update

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab21f0cc0832d85322a3e69267f71