### PR TITLE
Add audit change details to client update logging

### DIFF
--- a/Services/ApiLogRepository.cs
+++ b/Services/ApiLogRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Npgsql;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,30 +33,43 @@ public sealed class ApiLogRepository
                                 operation_type text        NOT NULL,
                                 username      text         NOT NULL,
                                 realm         text         NOT NULL,
-                                target_id     text         NOT NULL
+                                target_id     text         NOT NULL,
+                                details       text         NULL
                             );";
 
         await using (var cmd = new NpgsqlCommand(sql, conn))
             await cmd.ExecuteNonQueryAsync(ct);
 
+        const string alterSql = "alter table api_audit_logs add column if not exists details text null";
+
+        await using (var alterCmd = new NpgsqlCommand(alterSql, conn))
+            await alterCmd.ExecuteNonQueryAsync(ct);
+
         _initialized = true;
     }
 
-    public async Task LogAsync(string operationType, string username, string realm, string targetId, CancellationToken ct = default)
+    public async Task LogAsync(
+        string operationType,
+        string username,
+        string realm,
+        string targetId,
+        string? details = null,
+        CancellationToken ct = default)
     {
         await EnsureCreatedAsync(ct);
 
         await using var conn = new NpgsqlConnection(_connString);
         await conn.OpenAsync(ct);
 
-        const string sql = @"insert into api_audit_logs (operation_type, username, realm, target_id)
-                              values (@op, @user, @realm, @target);";
+        const string sql = @"insert into api_audit_logs (operation_type, username, realm, target_id, details)
+                              values (@op, @user, @realm, @target, @details);";
 
         await using var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("op", operationType);
         cmd.Parameters.AddWithValue("user", username);
         cmd.Parameters.AddWithValue("realm", realm);
         cmd.Parameters.AddWithValue("target", targetId);
+        cmd.Parameters.AddWithValue("details", (object?)details ?? DBNull.Value);
 
         await cmd.ExecuteNonQueryAsync(ct);
     }


### PR DESCRIPTION
## Summary
- extend API log storage with an optional details column and persist the value during audit logging
- capture detailed client update differences and include them in audit entries

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cac3602204832d9559a7a7dbe514dd