### PR TITLE
Add kc-gf- prefix to local roles input on create

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -220,8 +220,11 @@
                 <div class="text-slate-200 font-semibold text-lg">6. Local roles</div>
                 <div class="hint">Создаются на этом клиенте для назначения другим клиентам/пользователям для доступа.</div>
                 <div id="locList" class="flex flex-wrap gap-2"></div>
-                <div class="flex gap-2">
-                    <input id="locInput" maxlength="25" class="kc-input rounded-xl px-3 py-2 text-sm w-full md:w-72" placeholder="Например: app.read" autocomplete="off" autocapitalize="off" spellcheck="false" />
+                <div class="flex gap-2 items-center">
+                    <div class="prefix-wrap w-full md:w-72">
+                        <span class="prefix-chip">kc-gf-</span>
+                        <input id="locInput" maxlength="25" class="prefix-input text-sm" placeholder="Например: app.read" autocomplete="off" autocapitalize="off" spellcheck="false" />
+                    </div>
                     <button type="button" class="btn-subtle" onclick="addLocal()">Add</button>
                 </div>
             </div>
@@ -526,7 +529,9 @@
           };
           window.addLocal = function(){
             const v = trim(locInput?.value); if(!v) return;
-            locals.push(v); locInput.value=''; renderChips(locList, locals);
+            const prefix = 'kc-gf-';
+            const valueWithPrefix = v.startsWith(prefix) ? v : prefix + v;
+            locals.push(valueWithPrefix); locInput.value=''; renderChips(locList, locals);
           };
 
           // Submit


### PR DESCRIPTION
## Summary
- display the `kc-gf-` prefix chip for the local roles input on the create wizard
- ensure newly added local roles are stored with the `kc-gf-` prefix applied once

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caf9446310832dbc9e843908b47ac0