### PR TITLE
Prevent title flicker when navigating client pages

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -79,7 +79,7 @@
                     load(a.href);
                     const url = new URL(a.href, window.location);
                     url.searchParams.delete('handler');
-                    history.pushState({}, '', url);
+                    history.pushState({}, document.title, url);
                 });
             });
         };


### PR DESCRIPTION
## Summary
- preserve the existing document title when updating history in the client list filter script to keep the tab label stable

## Testing
- dotnet build *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb05fce0cc832d8d7a4afcce6e76ec