### PR TITLE
Prevent pagination from altering tab title

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -50,6 +50,8 @@
         const container = document.getElementById('clientsContainer');
         if (!input || !container) return;
 
+        const staticTitle = document.title;
+
         const applyFilter = () => {
             const q = input.value.trim().toLowerCase();
             const cards = container.querySelectorAll('.client-card');
@@ -80,11 +82,15 @@
                     const url = new URL(a.href, window.location);
                     url.searchParams.delete('handler');
                     history.pushState({}, document.title, url);
+                    document.title = staticTitle;
                 });
             });
         };
 
         attach();
+        window.addEventListener('popstate', () => {
+            document.title = staticTitle;
+        });
     })();
 </script>
 


### PR DESCRIPTION
## Summary
- capture the initial page title before binding pagination handlers
- restore the stored title after pushState and when navigating via browser history

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb09523ae0832d94badeb2ff208ecd