### PR TITLE
Refine Keycloak client services and shared client form utilities

### DIFF
--- a/KeyCloak/ClientsService.cs
+++ b/KeyCloak/ClientsService.cs
@@ -1,37 +1,35 @@
-﻿// Assistant/KeyCloak/ClientsService.cs
+using Assistant.KeyCloak.Models;
 using Assistant.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Assistant.KeyCloak
+namespace Assistant.KeyCloak;
+
+public sealed class ClientsService
 {
-    public sealed record ClientShort(string Id, string ClientId);
+    private readonly IHttpClientFactory _factory;
+    private readonly AdminApiOptions _opt;
+    private readonly ServiceRoleExclusionsRepository _exclusions;
+    private readonly ApiLogRepository _logs;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public sealed record ClientDetails(
-        string Id,
-        string ClientId,
-        bool Enabled,
-        string? Description,
-        bool ClientAuth,
-        bool StandardFlow,
-        bool ServiceAccount,
-        List<string> RedirectUris,
-        List<string> LocalRoles,
-        List<(string ClientId, string Role)> ServiceRoles,
-        List<string> DefaultScopes
-    );
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
 
-    // Ответы KC (берём только нужные поля)
     internal sealed class ClientRep
     {
         public string? Id { get; set; }
         public string? ClientId { get; set; }
     }
+
     internal sealed class ClientFullRep
     {
         public string? Id { get; set; }
@@ -49,6 +47,7 @@ namespace Assistant.KeyCloak
     {
         public string? Value { get; set; }
     }
+
     internal sealed class RoleRep
     {
         public string? Name { get; set; }
@@ -78,718 +77,602 @@ namespace Assistant.KeyCloak
         public List<RoleRep>? Mappings { get; set; }
     }
 
-    public sealed record RoleHit(string ClientUuid, string ClientId, string Role);
-
-    public sealed record NewClientSpec(
-        string Realm,
-        string ClientId,
-        string? Description,
-        bool ClientAuthentication,      // true => confidential (publicClient=false)
-        bool StandardFlow,
-        bool ServiceAccount,
-        List<string> RedirectUris,
-        List<string> LocalRoles,
-        List<(string ClientId, string Role)> ServiceRoles
-    );
-
-    public sealed record UpdateClientSpec(
-        string Realm,
-        string CurrentClientId,
-        string ClientId,
-        bool Enabled,
-        string? Description,
-        bool ClientAuth,
-        bool StandardFlow,
-        bool ServiceAccount,
-        List<string> RedirectUris,
-        List<string> LocalRoles,
-        List<(string ClientId, string Role)> ServiceRoles
-    );
-
-    /// <summary>
-    /// Работа с Keycloak Admin API: поиск/роли и создание клиента (без кэша).
-    /// </summary>
-    public class ClientsService
+    public ClientsService(
+        IHttpClientFactory factory,
+        IOptions<AdminApiOptions> opt,
+        ServiceRoleExclusionsRepository exclusions,
+        ApiLogRepository logs,
+        IHttpContextAccessor httpContextAccessor)
     {
-        private readonly IHttpClientFactory _factory;
-        private readonly AdminApiOptions _opt;
-        private readonly ServiceRoleExclusionsRepository _exclusions;
-        private readonly ApiLogRepository _logs;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        _factory = factory;
+        _opt = opt.Value;
+        _exclusions = exclusions;
+        _logs = logs;
+        _httpContextAccessor = httpContextAccessor;
+    }
 
-        public ClientsService(
-            IHttpClientFactory factory,
-            IOptions<AdminApiOptions> opt,
-            ServiceRoleExclusionsRepository exclusions,
-            ApiLogRepository logs,
-            IHttpContextAccessor httpContextAccessor)
+    private HttpClient CreateAdminClient() => _factory.CreateClient("kc-admin");
+
+    private string BaseUrl => _opt.BaseUrl.TrimEnd('/');
+
+    private string ResolveUsername()
+    {
+        var username = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+        return string.IsNullOrWhiteSpace(username) ? "unknown" : username;
+    }
+
+    private Task AuditAsync(string operationType, string realm, string targetId, CancellationToken ct, string? details = null)
+    {
+        realm = string.IsNullOrWhiteSpace(realm) ? "-" : realm;
+        targetId = string.IsNullOrWhiteSpace(targetId) ? "-" : targetId;
+        return _logs.LogAsync(operationType, ResolveUsername(), realm, targetId, details, ct);
+    }
+
+    private static string? DescribeClientUpdateChanges(ClientDetails before, UpdateClientSpec after)
+    {
+        var changes = new List<string>();
+
+        static string NormalizeSingle(string? value)
+            => string.IsNullOrWhiteSpace(value) ? "-" : value.Trim();
+
+        void AddStringChange(string field, string? oldValue, string? newValue)
         {
-            _factory = factory;
-            _opt = opt.Value;
-            _exclusions = exclusions;
-            _logs = logs;
-            _httpContextAccessor = httpContextAccessor;
+            var oldNorm = NormalizeSingle(oldValue);
+            var newNorm = NormalizeSingle(newValue);
+            if (!string.Equals(oldNorm, newNorm, StringComparison.Ordinal))
+            {
+                changes.Add($"{field}: '{oldNorm}' → '{newNorm}'");
+            }
         }
 
-        private string BaseUrl => _opt.BaseUrl.TrimEnd('/');
-
-        private string ResolveUsername()
+        void AddBoolChange(string field, bool oldValue, bool newValue)
         {
-            var username = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
-            return string.IsNullOrWhiteSpace(username) ? "unknown" : username;
+            if (oldValue != newValue)
+            {
+                changes.Add($"{field}: {oldValue.ToString().ToLowerInvariant()} → {newValue.ToString().ToLowerInvariant()}");
+            }
         }
 
-        private Task AuditAsync(string operationType, string realm, string targetId, CancellationToken ct, string? details = null)
+        static IEnumerable<string> NormalizeList(IEnumerable<string> source)
+            => source
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Select(s => s.Trim());
+
+        void AddSetChange(string field, IEnumerable<string> beforeSet, IEnumerable<string> afterSet, bool includeRemoved = true)
         {
-            realm = string.IsNullOrWhiteSpace(realm) ? "-" : realm;
-            targetId = string.IsNullOrWhiteSpace(targetId) ? "-" : targetId;
-            return _logs.LogAsync(operationType, ResolveUsername(), realm, targetId, details, ct);
-        }
+            var beforeList = NormalizeList(beforeSet).Distinct(StringComparer.Ordinal).ToList();
+            var afterList = NormalizeList(afterSet).Distinct(StringComparer.Ordinal).ToList();
 
-        private static string? DescribeClientUpdateChanges(ClientDetails before, UpdateClientSpec after)
-        {
-            var changes = new List<string>();
+            var beforeHash = new HashSet<string>(beforeList, StringComparer.Ordinal);
+            var afterHash = new HashSet<string>(afterList, StringComparer.Ordinal);
 
-            static string NormalizeSingle(string? value)
-                => string.IsNullOrWhiteSpace(value) ? "-" : value.Trim();
-
-            void AddStringChange(string field, string? oldValue, string? newValue)
-            {
-                var oldNorm = NormalizeSingle(oldValue);
-                var newNorm = NormalizeSingle(newValue);
-                if (!string.Equals(oldNorm, newNorm, StringComparison.Ordinal))
-                {
-                    changes.Add($"{field}: '{oldNorm}' → '{newNorm}'");
-                }
-            }
-
-            void AddBoolChange(string field, bool oldValue, bool newValue)
-            {
-                if (oldValue != newValue)
-                {
-                    changes.Add($"{field}: {oldValue.ToString().ToLowerInvariant()} → {newValue.ToString().ToLowerInvariant()}");
-                }
-            }
-
-            static IEnumerable<string> NormalizeList(IEnumerable<string> source)
-                => source
-                    .Where(s => !string.IsNullOrWhiteSpace(s))
-                    .Select(s => s.Trim());
-
-            void AddSetChange(string field, IEnumerable<string> beforeSet, IEnumerable<string> afterSet, bool includeRemoved = true)
-            {
-                var beforeList = NormalizeList(beforeSet).Distinct(StringComparer.Ordinal).ToList();
-                var afterList = NormalizeList(afterSet).Distinct(StringComparer.Ordinal).ToList();
-
-                var beforeHash = new HashSet<string>(beforeList, StringComparer.Ordinal);
-                var afterHash = new HashSet<string>(afterList, StringComparer.Ordinal);
-
-                var added = afterList.Where(item => !beforeHash.Contains(item)).ToList();
-                var removed = includeRemoved
-                    ? beforeList.Where(item => !afterHash.Contains(item)).ToList()
-                    : new List<string>();
-
-                if (added.Count == 0 && removed.Count == 0)
-                {
-                    return;
-                }
-
-                var parts = new List<string>();
-                if (added.Count > 0)
-                {
-                    parts.Add($"added [{string.Join(", ", added)}]");
-                }
-
-                if (includeRemoved && removed.Count > 0)
-                {
-                    parts.Add($"removed [{string.Join(", ", removed)}]");
-                }
-
-                if (parts.Count > 0)
-                {
-                    changes.Add($"{field}: {string.Join("; ", parts)}");
-                }
-            }
-
-            AddStringChange("clientId", before.ClientId, after.ClientId);
-            AddBoolChange("enabled", before.Enabled, after.Enabled);
-            AddStringChange("description", before.Description, after.Description);
-            AddBoolChange("clientAuth", before.ClientAuth, after.ClientAuth);
-            AddBoolChange("standardFlow", before.StandardFlow, after.StandardFlow);
-            AddBoolChange("serviceAccount", before.ServiceAccount, after.ServiceAccount);
-
-            var desiredRedirects = after.StandardFlow
-                ? after.RedirectUris ?? new List<string>()
+            var added = afterList.Where(item => !beforeHash.Contains(item)).ToList();
+            var removed = includeRemoved
+                ? beforeList.Where(item => !afterHash.Contains(item)).ToList()
                 : new List<string>();
-            AddSetChange("redirectUris", before.RedirectUris, desiredRedirects);
 
-            AddSetChange("localRoles", before.LocalRoles, after.LocalRoles ?? new List<string>(), includeRemoved: false);
+            if (added.Count == 0 && removed.Count == 0)
+            {
+                return;
+            }
 
-            var beforeServiceRoles = before.ServiceRoles
-                .Where(p => !string.IsNullOrWhiteSpace(p.ClientId) && !string.IsNullOrWhiteSpace(p.Role))
-                .Select(p => $"{p.ClientId.Trim()}:{p.Role.Trim()}")
-                .ToList();
-            var afterServiceRoles = (after.ServiceRoles ?? new List<(string ClientId, string Role)>())
-                .Where(p => !string.IsNullOrWhiteSpace(p.ClientId) && !string.IsNullOrWhiteSpace(p.Role))
-                .Select(p => $"{p.ClientId.Trim()}:{p.Role.Trim()}")
-                .ToList();
-            AddSetChange("serviceRoles", beforeServiceRoles, afterServiceRoles, includeRemoved: false);
+            var parts = new List<string>();
+            if (added.Count > 0)
+            {
+                parts.Add($"added [{string.Join(", ", added)}]");
+            }
 
-            return changes.Count == 0 ? null : string.Join("; ", changes);
+            if (includeRemoved && removed.Count > 0)
+            {
+                parts.Add($"removed [{string.Join(", ", removed)}]");
+            }
+
+            if (parts.Count > 0)
+            {
+                changes.Add($"{field}: {string.Join("; ", parts)}");
+            }
         }
 
-        private static readonly JsonSerializerOptions JsonOpts = new()
+        AddStringChange("clientId", before.ClientId, after.ClientId);
+        AddBoolChange("enabled", before.Enabled, after.Enabled);
+        AddStringChange("description", before.Description, after.Description);
+        AddBoolChange("clientAuth", before.ClientAuth, after.ClientAuth);
+        AddBoolChange("standardFlow", before.StandardFlow, after.StandardFlow);
+        AddBoolChange("serviceAccount", before.ServiceAccount, after.ServiceAccount);
+
+        var desiredRedirects = after.StandardFlow ? after.RedirectUris : Array.Empty<string>();
+        AddSetChange("redirectUris", before.RedirectUris, desiredRedirects);
+
+        AddSetChange("localRoles", before.LocalRoles, after.LocalRoles, includeRemoved: false);
+
+        var beforeServiceRoles = before.ServiceRoles
+            .Where(p => !string.IsNullOrWhiteSpace(p.ClientId) && !string.IsNullOrWhiteSpace(p.Role))
+            .Select(p => $"{p.ClientId.Trim()}:{p.Role.Trim()}")
+            .ToList();
+        var afterServiceRoles = after.ServiceRoles
+            .Where(p => !string.IsNullOrWhiteSpace(p.ClientId) && !string.IsNullOrWhiteSpace(p.Role))
+            .Select(p => $"{p.ClientId.Trim()}:{p.Role.Trim()}")
+            .ToList();
+        AddSetChange("serviceRoles", beforeServiceRoles, afterServiceRoles, includeRemoved: false);
+
+        return changes.Count == 0 ? null : string.Join("; ", changes);
+    }
+
+    private static string UR(string s) => Uri.EscapeDataString(s);
+
+    public async Task<List<ClientShort>> SearchClientsAsync(
+        string realm, string query, int first = 0, int max = 20, CancellationToken ct = default)
+    {
+        query = (query ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(query))
         {
-            PropertyNameCaseInsensitive = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
+            return new();
+        }
 
-        private static string UR(string s) => Uri.EscapeDataString(s);
+        first = Math.Max(0, first);
+        max = Math.Clamp(max <= 0 ? 20 : max, 1, 200);
 
-        // ======= Public: Search/List/Roles =======
+        var http = CreateAdminClient();
+        var excluded = await _exclusions.GetAllAsync(ct);
 
-        /// <summary>
-        /// Поиск клиентов по подстроке в clientId (CI). Возвращает только Id и ClientId.
-        /// </summary>
-        public async Task<List<ClientShort>> SearchClientsAsync(
-            string realm, string query, int first = 0, int max = 20, CancellationToken ct = default)
+        var urlExactNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients?clientId={UR(query)}&briefRepresentation=true";
+        var urlExactLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients?clientId={UR(query)}&briefRepresentation=true";
+
+        using (var resp = await http.GetWithLegacyFallbackAsync(urlExactNew, urlExactLegacy, ct))
         {
-            query = (query ?? "").Trim();
-            if (string.IsNullOrEmpty(query))
-            {
-                return new();
-            }
-            first = Math.Max(0, first);
-            max = Math.Clamp(max <= 0 ? 20 : max, 1, 200);
+            resp.EnsureAdminSuccess();
+            var exact = await ReadJsonAsync<List<ClientRep>>(resp, ct) ?? new();
 
-            var http = _factory.CreateClient("kc-admin");
-            var excluded = await _exclusions.GetAllAsync(ct);
-
-            // 1) Точное clientId=
-            var urlExactNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients?clientId={UR(query)}&briefRepresentation=true";
-            var urlExactLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients?clientId={UR(query)}&briefRepresentation=true";
-
-            var resp = await GetAsyncWithFallback(http, urlExactNew, urlExactLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var exact = await ReadJson<List<ClientRep>>(resp, ct) ?? new();
-
-            static bool ContainsCi(string? s, string needle) =>
-                !string.IsNullOrEmpty(s) && s.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+            static bool ContainsCi(string? s, string needle)
+                => !string.IsNullOrEmpty(s) && s.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
 
             var mappedExact = exact
                 .Where(x => !string.IsNullOrWhiteSpace(x.ClientId))
                 .Select(MapClient)
                 .Where(c => ContainsCi(c.ClientId, query))
                 .ToList();
-            mappedExact = FilterExcluded(mappedExact, excluded);
 
-            if (mappedExact.Count > 0)
+            var filteredExact = FilterExcluded(mappedExact, excluded);
+            if (filteredExact.Count > 0)
             {
-                return mappedExact;
+                return filteredExact;
+            }
+        }
+
+        var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients?search={UR(query)}&first={first}&max={max}&briefRepresentation=true";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients?search={UR(query)}&first={first}&max={max}&briefRepresentation=true";
+
+        using var resp2 = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp2.EnsureAdminSuccess();
+        var list = await ReadJsonAsync<List<ClientRep>>(resp2, ct) ?? new();
+
+        var mapped = list
+            .Where(x => !string.IsNullOrWhiteSpace(x.ClientId))
+            .Select(MapClient)
+            .Where(c => c.ClientId.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0)
+            .ToList();
+
+        return FilterExcluded(mapped, excluded);
+
+        static ClientShort MapClient(ClientRep c) => new(c.Id ?? string.Empty, c.ClientId ?? string.Empty);
+    }
+
+    public async Task<(List<ClientShort> Clients, int TotalFetched)> ListClientsAsync(
+        string realm, int first = 0, int max = 50, CancellationToken ct = default)
+    {
+        first = Math.Max(0, first);
+        max = Math.Clamp(max <= 0 ? 50 : max, 1, 200);
+
+        var http = CreateAdminClient();
+        var excluded = await _exclusions.GetAllAsync(ct);
+
+        var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients?first={first}&max={max}&briefRepresentation=true";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients?first={first}&max={max}&briefRepresentation=true";
+
+        using var resp = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp.EnsureAdminSuccess();
+        var list = await ReadJsonAsync<List<ClientRep>>(resp, ct) ?? new();
+
+        var mapped = list
+            .Where(x => !string.IsNullOrWhiteSpace(x.ClientId))
+            .Select(c => new ClientShort(c.Id ?? string.Empty, c.ClientId ?? string.Empty))
+            .ToList();
+
+        var filtered = FilterExcluded(mapped, excluded);
+        await AuditAsync("client:list", realm, $"{first}:{max}", ct);
+        return (filtered, mapped.Count);
+    }
+
+    public async Task<ClientDetails?> GetClientDetailsAsync(string realm, string clientId, CancellationToken ct = default)
+    {
+        var http = CreateAdminClient();
+
+        var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients?clientId={UR(clientId)}";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients?clientId={UR(clientId)}";
+
+        using var resp = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp.EnsureAdminSuccess();
+        var list = await ReadJsonAsync<List<ClientFullRep>>(resp, ct) ?? new();
+        var rep = list.FirstOrDefault(c => string.Equals(c.ClientId, clientId, StringComparison.OrdinalIgnoreCase));
+        if (rep == null || string.IsNullOrWhiteSpace(rep.Id) || string.IsNullOrWhiteSpace(rep.ClientId))
+        {
+            return null;
+        }
+
+        var localRoles = await GetClientRolesAsync(realm, rep.Id!, 0, 1000, null, ct);
+        var svcRoles = (rep.ServiceAccountsEnabled ?? false)
+            ? await GetServiceAccountRolesAsync(realm, rep.Id!, ct)
+            : new List<(string ClientId, string Role)>();
+        var defaultScopes = rep.DefaultClientScopes?.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s!).ToList() ?? new();
+
+        var details = new ClientDetails(
+            rep.Id!,
+            rep.ClientId!,
+            rep.Enabled ?? false,
+            rep.Description,
+            !(rep.PublicClient ?? true),
+            rep.StandardFlowEnabled ?? false,
+            rep.ServiceAccountsEnabled ?? false,
+            rep.RedirectUris?.Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r!).ToList() ?? new List<string>(),
+            localRoles,
+            svcRoles,
+            defaultScopes
+        );
+        return details;
+    }
+
+    public async Task<string?> GetClientSecretAsync(string realm, string clientId, CancellationToken ct = default)
+    {
+        var details = await GetClientDetailsAsync(realm, clientId, ct);
+        if (details == null)
+        {
+            return null;
+        }
+
+        var http = CreateAdminClient();
+        var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(details.Id)}/client-secret";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(details.Id)}/client-secret";
+
+        using var resp = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp.EnsureAdminSuccess();
+        var rep = await ReadJsonAsync<ClientSecretRep>(resp, ct);
+        return rep?.Value;
+    }
+
+    public async Task<string?> RegenerateClientSecretAsync(string realm, string clientId, CancellationToken ct = default)
+    {
+        var details = await GetClientDetailsAsync(realm, clientId, ct);
+        if (details == null)
+        {
+            await AuditAsync("client-secret:regenerate", realm, clientId, ct);
+            return null;
+        }
+
+        var http = CreateAdminClient();
+        var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(details.Id)}/client-secret";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(details.Id)}/client-secret";
+
+        using var resp = await http.PostWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp.EnsureAdminSuccess();
+        var rep = await ReadJsonAsync<ClientSecretRep>(resp, ct);
+        var secret = rep?.Value;
+        await AuditAsync("client-secret:regenerate", realm, details.ClientId, ct);
+        return secret;
+    }
+
+    public async Task<List<string>> GetClientRolesAsync(
+        string realm, string clientUuid, int first = 0, int max = 50, string? search = null, CancellationToken ct = default)
+    {
+        first = Math.Max(0, first);
+        max = Math.Clamp(max <= 0 ? 50 : max, 1, 200);
+
+        var http = CreateAdminClient();
+        var qs = $"briefRepresentation=true&first={first}&max={max}" +
+                 (string.IsNullOrWhiteSpace(search) ? string.Empty : $"&search={UR(search!)}");
+
+        var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/roles?{qs}";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/roles?{qs}";
+
+        using var resp = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp.EnsureAdminSuccess();
+        var roles = await ReadJsonAsync<List<RoleRep>>(resp, ct) ?? new();
+
+        return roles
+            .Select(r => r.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n!)
+            .ToList();
+    }
+
+    public async Task<(List<RoleHit> Hits, int NextClientFirst)> FindRolesAcrossClientsAsync(
+        string realm, string roleQuery, int clientFirst = 0, int clientsToScan = 25, int rolesPerClient = 10, CancellationToken ct = default)
+    {
+        roleQuery = (roleQuery ?? string.Empty).Trim();
+        if (roleQuery.Length == 0)
+        {
+            return (new List<RoleHit>(), -1);
+        }
+
+        var (clients, fetched) = await ListClientsAsync(realm, clientFirst, clientsToScan, ct);
+        var hits = new List<RoleHit>();
+
+        foreach (var client in clients)
+        {
+            var roles = await GetClientRolesAsync(realm, client.Id, 0, rolesPerClient, roleQuery, ct);
+            foreach (var role in roles)
+            {
+                hits.Add(new RoleHit(client.Id, client.ClientId, role));
+            }
+        }
+
+        var next = fetched < clientsToScan ? -1 : clientFirst + fetched;
+        return (hits, next);
+    }
+
+    public async Task<string> CreateClientAsync(NewClientSpec spec, CancellationToken ct = default)
+    {
+        var http = CreateAdminClient();
+
+        var body = new
+        {
+            clientId = spec.ClientId,
+            protocol = "openid-connect",
+            publicClient = !spec.ClientAuthentication,
+            serviceAccountsEnabled = spec.ServiceAccount,
+            standardFlowEnabled = spec.StandardFlow,
+            directAccessGrantsEnabled = false,
+            redirectUris = spec.RedirectUris.Distinct().ToArray(),
+            description = spec.Description
+        };
+
+        var postNew = $"{BaseUrl}/admin/realms/{UR(spec.Realm)}/clients";
+        var postLegacy = $"{BaseUrl}/auth/admin/realms/{UR(spec.Realm)}/clients";
+
+        using var createResp = await http.PostJsonWithLegacyFallbackAsync(postNew, postLegacy, body, JsonOpts, ct);
+        if (createResp.StatusCode == HttpStatusCode.Conflict)
+        {
+            throw new InvalidOperationException($"Client '{spec.ClientId}' already exists.");
+        }
+
+        createResp.EnsureAdminSuccess();
+
+        string? createdId = null;
+        if (createResp.Headers.Location is Uri loc)
+        {
+            var segment = loc.Segments.LastOrDefault();
+            if (!string.IsNullOrWhiteSpace(segment))
+            {
+                createdId = segment.TrimEnd('/');
+            }
+        }
+
+        createdId ??= (await SearchClientsAsync(spec.Realm, spec.ClientId, 0, 1, ct))
+            .FirstOrDefault(c => string.Equals(c.ClientId, spec.ClientId, StringComparison.OrdinalIgnoreCase))?.Id
+            ?? throw new InvalidOperationException("Cannot resolve created client id.");
+
+        try
+        {
+            if (spec.LocalRoles.Count > 0)
+            {
+                await EnsureLocalRolesAsync(spec.Realm, createdId, spec.LocalRoles, ct);
             }
 
-            // 2) search= + пагинация
-            var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients?search={UR(query)}&first={first}&max={max}&briefRepresentation=true";
-            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients?search={UR(query)}&first={first}&max={max}&briefRepresentation=true";
-
-            var resp2 = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
-            EnsureAuthOrThrow(resp2);
-            var list = await ReadJson<List<ClientRep>>(resp2, ct) ?? new();
-
-            var mapped = list
-                .Where(x => !string.IsNullOrWhiteSpace(x.ClientId))
-                .Select(MapClient)
-                .Where(c => ContainsCi(c.ClientId, query))
-                .ToList();
-
-            var filtered = FilterExcluded(mapped, excluded);
-            return filtered;
-
-            static ClientShort MapClient(ClientRep c) => new ClientShort(
-                c.Id ?? string.Empty,
-                c.ClientId ?? string.Empty);
-        }
-
-        /// <summary>
-        /// Плоский листинг клиентов (для сканирования при поиске роли, когда клиент неизвестен).
-        /// </summary>
-        public async Task<(List<ClientShort> Clients, int TotalFetched)> ListClientsAsync(string realm, int first = 0, int max = 50, CancellationToken ct = default)
-        {
-            first = Math.Max(0, first);
-            max = Math.Clamp(max <= 0 ? 50 : max, 1, 200);
-
-            var http = _factory.CreateClient("kc-admin");
-            var excluded = await _exclusions.GetAllAsync(ct);
-
-            var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients?first={first}&max={max}&briefRepresentation=true";
-            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients?first={first}&max={max}&briefRepresentation=true";
-
-            var resp = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var list = await ReadJson<List<ClientRep>>(resp, ct) ?? new();
-
-            var mapped = list
-                .Where(x => !string.IsNullOrWhiteSpace(x.ClientId))
-                .Select(c => new ClientShort(c.Id ?? string.Empty, c.ClientId ?? string.Empty))
-                .ToList();
-            var total = mapped.Count;
-            var filtered = FilterExcluded(mapped, excluded);
-            await AuditAsync("client:list", realm, $"{first}:{max}", ct);
-            return (filtered, total);
-        }
-
-        /// <summary>
-        /// Полные сведения о клиенте вместе с ролями и redirect URIs.
-        /// </summary>
-        public async Task<ClientDetails?> GetClientDetailsAsync(string realm, string clientId, CancellationToken ct = default)
-        {
-            var http = _factory.CreateClient("kc-admin");
-
-            var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients?clientId={UR(clientId)}";
-            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients?clientId={UR(clientId)}";
-
-            using var resp = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var list = await ReadJson<List<ClientFullRep>>(resp, ct) ?? new();
-            var rep = list.FirstOrDefault(c => string.Equals(c.ClientId, clientId, StringComparison.OrdinalIgnoreCase));
-            if (rep == null || string.IsNullOrWhiteSpace(rep.Id) || string.IsNullOrWhiteSpace(rep.ClientId))
+            if (spec.ServiceAccount && spec.ServiceRoles.Count > 0)
             {
-                return null;
+                await AssignServiceRolesToServiceAccountAsync(spec.Realm, createdId, spec.ServiceRoles, ct);
             }
-
-            var localRoles = await GetClientRolesAsync(realm, rep.Id!, 0, 1000, null, ct);
-            var svcRoles = (rep.ServiceAccountsEnabled ?? false)
-                ? await GetServiceAccountRolesAsync(realm, rep.Id!, ct)
-                : new List<(string ClientId, string Role)>();
-            var defaultScopes = rep.DefaultClientScopes?.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s!).ToList() ?? new();
-
-            var details = new ClientDetails(
-                rep.Id!,
-                rep.ClientId!,
-                rep.Enabled ?? false,
-                rep.Description,
-                !(rep.PublicClient ?? true),
-                rep.StandardFlowEnabled ?? false,
-                rep.ServiceAccountsEnabled ?? false,
-                rep.RedirectUris?.Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r!).ToList() ?? new(),
-                localRoles,
-                svcRoles,
-                defaultScopes
-            );
-            return details;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Клиент '{spec.ClientId}' создан, но при назначении ролей произошла ошибка: {ex.Message}", ex);
         }
 
-        public async Task<string?> GetClientSecretAsync(string realm, string clientId, CancellationToken ct = default)
+        await AuditAsync("client:create", spec.Realm, spec.ClientId, ct);
+        return createdId;
+    }
+
+    public async Task UpdateClientAsync(UpdateClientSpec spec, CancellationToken ct = default)
+    {
+        var http = CreateAdminClient();
+
+        var existingDetails = await GetClientDetailsAsync(spec.Realm, spec.CurrentClientId, ct)
+            ?? throw new InvalidOperationException($"Client '{spec.CurrentClientId}' not found.");
+
+        var body = new
         {
-            var details = await GetClientDetailsAsync(realm, clientId, ct);
-            if (details == null)
-            {
-                return null;
-            }
+            clientId = spec.ClientId,
+            enabled = spec.Enabled,
+            publicClient = !spec.ClientAuth,
+            serviceAccountsEnabled = spec.ServiceAccount,
+            standardFlowEnabled = spec.StandardFlow,
+            directAccessGrantsEnabled = false,
+            redirectUris = spec.StandardFlow ? spec.RedirectUris.Distinct().ToArray() : Array.Empty<string>(),
+            description = spec.Description
+        };
 
-            var http = _factory.CreateClient("kc-admin");
-            var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(details.Id)}/client-secret";
-            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(details.Id)}/client-secret";
+        var putNew = $"{BaseUrl}/admin/realms/{UR(spec.Realm)}/clients/{UR(existingDetails.Id)}";
+        var putLegacy = $"{BaseUrl}/auth/admin/realms/{UR(spec.Realm)}/clients/{UR(existingDetails.Id)}";
 
-            using var resp = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var rep = await ReadJson<ClientSecretRep>(resp, ct);
-            var secret = rep?.Value;
-            return secret;
+        using var resp = await http.PutJsonWithLegacyFallbackAsync(putNew, putLegacy, body, JsonOpts, ct);
+        resp.EnsureAdminSuccess();
+
+        if (spec.LocalRoles.Count > 0)
+        {
+            await EnsureLocalRolesAsync(spec.Realm, existingDetails.Id, spec.LocalRoles, ct);
         }
 
-        public async Task<string?> RegenerateClientSecretAsync(string realm, string clientId, CancellationToken ct = default)
+        if (spec.ServiceAccount && spec.ServiceRoles.Count > 0)
         {
-            var details = await GetClientDetailsAsync(realm, clientId, ct);
-            if (details == null)
-            {
-                await AuditAsync("client-secret:regenerate", realm, clientId, ct);
-                return null;
-            }
-
-            var http = _factory.CreateClient("kc-admin");
-            var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(details.Id)}/client-secret";
-            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(details.Id)}/client-secret";
-
-            using var resp = await PostWithFallback(http, urlNew, urlLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var rep = await ReadJson<ClientSecretRep>(resp, ct);
-            var secret = rep?.Value;
-            await AuditAsync("client-secret:regenerate", realm, details.ClientId, ct);
-            return secret;
+            await AssignServiceRolesToServiceAccountAsync(spec.Realm, existingDetails.Id, spec.ServiceRoles, ct);
         }
 
-        /// <summary>
-        /// Роли клиента (с опциональным server-side search по названию роли).
-        /// </summary>
-        public async Task<List<string>> GetClientRolesAsync(
-            string realm, string clientUuid, int first = 0, int max = 50, string? search = null, CancellationToken ct = default)
+        var diff = DescribeClientUpdateChanges(existingDetails, spec);
+        await AuditAsync("client:update", spec.Realm, spec.ClientId, ct, diff);
+    }
+
+    public async Task DeleteClientAsync(string realm, string clientId, CancellationToken ct = default)
+    {
+        var http = CreateAdminClient();
+
+        var existing = (await SearchClientsAsync(realm, clientId, 0, 1, ct))
+            .FirstOrDefault(c => string.Equals(c.ClientId, clientId, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException($"Client '{clientId}' not found.");
+
+        var delNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(existing.Id)}";
+        var delLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(existing.Id)}";
+
+        using var resp = await http.DeleteWithLegacyFallbackAsync(delNew, delLegacy, ct);
+        resp.EnsureAdminSuccess();
+        var target = string.IsNullOrWhiteSpace(existing.Id)
+            ? (string.IsNullOrWhiteSpace(existing.ClientId) ? clientId : existing.ClientId)
+            : $"{existing.Id}:{existing.ClientId}";
+        await AuditAsync("client:delete", realm, target, ct);
+    }
+
+    private async Task EnsureLocalRolesAsync(string realm, string clientUuid, IEnumerable<string> roles, CancellationToken ct)
+    {
+        var http = CreateAdminClient();
+
+        foreach (var name in roles.Where(r => !string.IsNullOrWhiteSpace(r)).Distinct(StringComparer.OrdinalIgnoreCase))
         {
-            first = Math.Max(0, first);
-            max = Math.Clamp(max <= 0 ? 50 : max, 1, 200);
-
-            var http = _factory.CreateClient("kc-admin");
-            var qs = $"briefRepresentation=true&first={first}&max={max}" +
-                     (string.IsNullOrWhiteSpace(search) ? "" : $"&search={UR(search!)}");
-
-            var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/roles?{qs}";
-            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/roles?{qs}";
-
-            var resp = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var roles = await ReadJson<List<RoleRep>>(resp, ct) ?? new();
-
-            var list = roles.Select(r => r.Name)
-                             .Where(n => !string.IsNullOrWhiteSpace(n))
-                             .Select(n => n!)
-                             .ToList();
-            return list;
-        }
-
-        /// <summary>
-        /// Поиск ролей по подстроке, когда клиент неизвестен: сканируем пачку клиентов и берём роли с search=.
-        /// Возвращаем совпадения и смещение для следующей пачки.
-        /// </summary>
-        public async Task<(List<RoleHit> Hits, int NextClientFirst)> FindRolesAcrossClientsAsync(
-            string realm, string roleQuery, int clientFirst = 0, int clientsToScan = 25, int rolesPerClient = 10, CancellationToken ct = default)
-        {
-            roleQuery = (roleQuery ?? "").Trim();
-            if (roleQuery.Length == 0) return (new(), -1);
-
-            var (clients, fetched) = await ListClientsAsync(realm, clientFirst, clientsToScan, ct);
-            var hits = new List<RoleHit>();
-
-            foreach (var c in clients)
-            {
-                var roles = await GetClientRolesAsync(realm, c.Id, 0, rolesPerClient, roleQuery, ct);
-                foreach (var r in roles)
-                    hits.Add(new RoleHit(c.Id, c.ClientId, r));
-            }
-
-            var next = fetched < clientsToScan ? -1 : clientFirst + fetched;
-            return (hits, next);
-        }
-
-        private static List<ClientShort> FilterExcluded(List<ClientShort> source, HashSet<string> excluded)
-        {
-            if (excluded.Count == 0) return source;
-            source.RemoveAll(c => excluded.Contains(c.ClientId));
-            return source;
-        }
-
-        private async Task<List<(string ClientId, string Role)>> GetServiceAccountRolesAsync(string realm, string clientUuid, CancellationToken ct)
-        {
-            var http = _factory.CreateClient("kc-admin");
-
-            var getSvcUserNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/service-account-user";
-            var getSvcUserLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/service-account-user";
-
-            using var userResp = await GetAsyncWithFallback(http, getSvcUserNew, getSvcUserLegacy, ct);
-            EnsureAuthOrThrow(userResp);
-            var svcUser = await ReadJson<KcUserRep>(userResp, ct);
-            userResp.Dispose();
-            if (svcUser?.Id == null)
-            {
-                return new();
-            }
-
-            var mapUrlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/users/{UR(svcUser.Id)}/role-mappings";
-            var mapUrlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/users/{UR(svcUser.Id)}/role-mappings";
-
-            using var mapResp = await GetAsyncWithFallback(http, mapUrlNew, mapUrlLegacy, ct);
-            EnsureAuthOrThrow(mapResp);
-            var mappings = await ReadJson<RoleMappingsRep>(mapResp, ct);
-            mapResp.Dispose();
-
-            var list = new List<(string ClientId, string Role)>();
-            if (mappings?.ClientMappings != null)
-            {
-                foreach (var kv in mappings.ClientMappings)
-                {
-                    var roles = kv.Value.Mappings;
-                    if (roles == null) continue;
-                    foreach (var r in roles)
-                        if (!string.IsNullOrWhiteSpace(r.Name))
-                            list.Add((kv.Key, r.Name!));
-                }
-            }
-            return list;
-        }
-
-        // ======= Public: Create client (+ roles + service roles) =======
-
-        public async Task<string> CreateClientAsync(NewClientSpec spec, CancellationToken ct = default)
-        {
-            var http = _factory.CreateClient("kc-admin");
-
-            // 1) Создаём клиента
-            var body = new
-            {
-                clientId = spec.ClientId,
-                protocol = "openid-connect",
-                publicClient = !spec.ClientAuthentication,
-                serviceAccountsEnabled = spec.ServiceAccount,
-                standardFlowEnabled = spec.StandardFlow,
-                directAccessGrantsEnabled = false,
-                redirectUris = spec.RedirectUris?.Distinct().ToArray() ?? Array.Empty<string>(),
-                description = spec.Description
-            };
-
-            var postNew = $"{BaseUrl}/admin/realms/{UR(spec.Realm)}/clients";
-            var postLegacy = $"{BaseUrl}/auth/admin/realms/{UR(spec.Realm)}/clients";
-
-            var createResp = await PostJsonWithFallback(http, postNew, postLegacy, body, ct);
-            if (createResp.StatusCode == HttpStatusCode.Conflict)
-                throw new InvalidOperationException($"Client '{spec.ClientId}' already exists.");
-            EnsureAuthOrThrow(createResp);
-
-            // извлекаем id из Location
-            string? createdId = null;
-            if (createResp.Headers.Location is Uri loc)
-            {
-                var seg = loc.Segments.LastOrDefault();
-                if (!string.IsNullOrWhiteSpace(seg)) createdId = seg.TrimEnd('/');
-            }
-            createResp.Dispose();
-
-            // fallback: найдём по clientId, если Location не пришёл
-            createdId ??= (await SearchClientsAsync(spec.Realm, spec.ClientId, 0, 1, ct))
-                .FirstOrDefault(c => string.Equals(c.ClientId, spec.ClientId, StringComparison.OrdinalIgnoreCase))?.Id
-                ?? throw new InvalidOperationException("Cannot resolve created client id.");
-
-            // 2) Локальные роли
             try
             {
-                if (spec.LocalRoles?.Count > 0)
-                    await EnsureLocalRolesAsync(spec.Realm, createdId, spec.LocalRoles, ct);
+                var payload = new { name = name.Trim() };
 
-                // 3) Service roles → назначаем на сервис-аккаунт нового клиента
-                if (spec.ServiceAccount && spec.ServiceRoles?.Count > 0)
-                    await AssignServiceRolesToServiceAccountAsync(spec.Realm, createdId, spec.ServiceRoles, ct);
+                var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/roles";
+                var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/roles";
+
+                using var resp = await http.PostJsonWithLegacyFallbackAsync(urlNew, urlLegacy, payload, JsonOpts, ct);
+
+                if (resp.StatusCode == HttpStatusCode.Conflict)
+                {
+                    continue;
+                }
+
+                resp.EnsureAdminSuccess();
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException(
-                    $"Клиент '{spec.ClientId}' создан, но при назначении ролей произошла ошибка: {ex.Message}", ex);
+                throw new InvalidOperationException($"Локальная роль '{name}' не назначена: {ex.Message}", ex);
+            }
+        }
+    }
+
+    private async Task AssignServiceRolesToServiceAccountAsync(string realm, string newClientUuid, IReadOnlyList<(string ClientId, string Role)> pairs, CancellationToken ct)
+    {
+        var http = CreateAdminClient();
+
+        var getSvcUserNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(newClientUuid)}/service-account-user";
+        var getSvcUserLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(newClientUuid)}/service-account-user";
+
+        using var userResp = await http.GetWithLegacyFallbackAsync(getSvcUserNew, getSvcUserLegacy, ct);
+        userResp.EnsureAdminSuccess();
+        var svcUser = await ReadJsonAsync<KcUserRep>(userResp, ct) ?? throw new InvalidOperationException("Service account user not found.");
+        if (string.IsNullOrWhiteSpace(svcUser.Id))
+        {
+            throw new InvalidOperationException("Service account user id is empty.");
+        }
+
+        var groups = pairs
+            .Where(p => !string.IsNullOrWhiteSpace(p.ClientId) && !string.IsNullOrWhiteSpace(p.Role))
+            .GroupBy(p => p.ClientId.Trim(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in groups)
+        {
+            var srcClientId = group.Key;
+
+            var srcClient = (await SearchClientsAsync(realm, srcClientId, 0, 2, ct))
+                .FirstOrDefault(c => string.Equals(c.ClientId, srcClientId, StringComparison.OrdinalIgnoreCase));
+            if (srcClient == null)
+            {
+                throw new InvalidOperationException($"Client '{srcClientId}' not found.");
             }
 
-            await AuditAsync("client:create", spec.Realm, spec.ClientId, ct);
-            return createdId;
-        }
+            var mapNewBase = $"{BaseUrl}/admin/realms/{UR(realm)}/users/{UR(svcUser.Id!)}/role-mappings/clients/{UR(srcClient.Id)}";
+            var mapLegacyBase = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/users/{UR(svcUser.Id!)}/role-mappings/clients/{UR(srcClient.Id)}";
 
-        public async Task UpdateClientAsync(UpdateClientSpec spec, CancellationToken ct = default)
-        {
-            var http = _factory.CreateClient("kc-admin");
-
-            var existingDetails = await GetClientDetailsAsync(spec.Realm, spec.CurrentClientId, ct)
-                ?? throw new InvalidOperationException($"Client '{spec.CurrentClientId}' not found.");
-
-            var body = new
-            {
-                clientId = spec.ClientId,
-                enabled = spec.Enabled,
-                publicClient = !spec.ClientAuth,
-                serviceAccountsEnabled = spec.ServiceAccount,
-                standardFlowEnabled = spec.StandardFlow,
-                directAccessGrantsEnabled = false,
-                redirectUris = spec.StandardFlow ? spec.RedirectUris?.Distinct().ToArray() ?? Array.Empty<string>() : Array.Empty<string>(),
-                description = spec.Description
-            };
-
-            var putNew = $"{BaseUrl}/admin/realms/{UR(spec.Realm)}/clients/{UR(existingDetails.Id)}";
-            var putLegacy = $"{BaseUrl}/auth/admin/realms/{UR(spec.Realm)}/clients/{UR(existingDetails.Id)}";
-
-            using var resp = await PutJsonWithFallback(http, putNew, putLegacy, body, ct);
-            EnsureAuthOrThrow(resp);
-
-            if (spec.LocalRoles?.Count > 0)
-                await EnsureLocalRolesAsync(spec.Realm, existingDetails.Id, spec.LocalRoles, ct);
-
-            if (spec.ServiceAccount && spec.ServiceRoles?.Count > 0)
-                await AssignServiceRolesToServiceAccountAsync(spec.Realm, existingDetails.Id, spec.ServiceRoles, ct);
-
-            var diff = DescribeClientUpdateChanges(existingDetails, spec);
-            await AuditAsync("client:update", spec.Realm, spec.ClientId, ct, diff);
-        }
-
-        public async Task DeleteClientAsync(string realm, string clientId, CancellationToken ct = default)
-        {
-            var http = _factory.CreateClient("kc-admin");
-
-            var existing = (await SearchClientsAsync(realm, clientId, 0, 1, ct))
-                .FirstOrDefault(c => string.Equals(c.ClientId, clientId, StringComparison.OrdinalIgnoreCase))
-                ?? throw new InvalidOperationException($"Client '{clientId}' not found.");
-
-            var delNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(existing.Id)}";
-            var delLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(existing.Id)}";
-
-            using var resp = await DeleteWithFallback(http, delNew, delLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var target = string.IsNullOrWhiteSpace(existing.Id)
-                ? (string.IsNullOrWhiteSpace(existing.ClientId) ? clientId : existing.ClientId)
-                : $"{existing.Id}:{existing.ClientId}";
-            await AuditAsync("client:delete", realm, target, ct);
-        }
-
-        // ======= Internal helpers for Create =======
-
-        private async Task EnsureLocalRolesAsync(string realm, string clientUuid, IEnumerable<string> roles, CancellationToken ct)
-        {
-            var http = _factory.CreateClient("kc-admin");
-
-            foreach (var name in roles.Where(r => !string.IsNullOrWhiteSpace(r)).Distinct(StringComparer.OrdinalIgnoreCase))
+            foreach (var roleName in group.Select(x => x.Role.Trim()).Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 try
                 {
-                    var payload = new { name = name.Trim() };
+                    var getRoleNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(srcClient.Id)}/roles/{UR(roleName)}";
+                    var getRoleLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(srcClient.Id)}/roles/{UR(roleName)}";
 
-                    var urlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/roles";
-                    var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/roles";
+                    using var rr = await http.GetWithLegacyFallbackAsync(getRoleNew, getRoleLegacy, ct);
+                    rr.EnsureAdminSuccess();
+                    var rep = await ReadJsonAsync<KcRoleRep>(rr, ct) ?? new KcRoleRep { Name = roleName };
+                    rep.ClientRole = true;
+                    rep.ContainerId = srcClient.Id;
 
-                    using var resp = await PostJsonWithFallback(http, urlNew, urlLegacy, payload, ct);
-
-                    if (resp.StatusCode == HttpStatusCode.Conflict)
-                    {
-                        continue;
-                    }
-                    EnsureAuthOrThrow(resp);
+                    using var mapResp = await http.PostJsonWithLegacyFallbackAsync(mapNewBase, mapLegacyBase, new[] { rep }, JsonOpts, ct);
+                    mapResp.EnsureAdminSuccess();
+                    await AuditAsync("service-account:role-assign", realm, $"{newClientUuid}:{srcClientId}:{roleName}", ct);
                 }
                 catch (Exception ex)
                 {
-                    throw new InvalidOperationException($"Локальная роль '{name}' не назначена: {ex.Message}", ex);
+                    throw new InvalidOperationException($"Сервисная роль '{roleName}' клиента '{srcClientId}' не назначена: {ex.Message}", ex);
                 }
             }
         }
-
-        private async Task AssignServiceRolesToServiceAccountAsync(string realm, string newClientUuid, List<(string ClientId, string Role)> pairs, CancellationToken ct)
-        {
-            var http = _factory.CreateClient("kc-admin");
-
-            // userId сервис-аккаунта нового клиента
-            var getSvcUserNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(newClientUuid)}/service-account-user";
-            var getSvcUserLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(newClientUuid)}/service-account-user";
-
-            var userResp = await GetAsyncWithFallback(http, getSvcUserNew, getSvcUserLegacy, ct);
-            EnsureAuthOrThrow(userResp);
-            var svcUser = await ReadJson<KcUserRep>(userResp, ct) ?? throw new InvalidOperationException("Service account user not found.");
-            userResp.Dispose();
-            if (string.IsNullOrWhiteSpace(svcUser.Id)) throw new InvalidOperationException("Service account user id is empty.");
-
-            // Группируем роли по исходному клиенту: clientId → [roleName]
-            var groups = pairs
-                .Where(p => !string.IsNullOrWhiteSpace(p.ClientId) && !string.IsNullOrWhiteSpace(p.Role))
-                .GroupBy(p => p.ClientId.Trim(), StringComparer.OrdinalIgnoreCase);
-
-            foreach (var g in groups)
-            {
-                var srcClientId = g.Key;
-
-                // найдём UUID исходного клиента по его clientId
-                var srcClient = (await SearchClientsAsync(realm, srcClientId, 0, 2, ct))
-                    .FirstOrDefault(c => string.Equals(c.ClientId, srcClientId, StringComparison.OrdinalIgnoreCase));
-                if (srcClient == null) throw new InvalidOperationException($"Client '{srcClientId}' not found.");
-
-                var mapNewBase = $"{BaseUrl}/admin/realms/{UR(realm)}/users/{UR(svcUser.Id!)}/role-mappings/clients/{UR(srcClient.Id)}";
-                var mapLegacyBase = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/users/{UR(svcUser.Id!)}/role-mappings/clients/{UR(srcClient.Id)}";
-
-                foreach (var roleName in g.Select(x => x.Role.Trim()).Distinct(StringComparer.OrdinalIgnoreCase))
-                {
-                    try
-                    {
-                        var getRoleNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(srcClient.Id)}/roles/{UR(roleName)}";
-                        var getRoleLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(srcClient.Id)}/roles/{UR(roleName)}";
-
-                        using var rr = await GetAsyncWithFallback(http, getRoleNew, getRoleLegacy, ct);
-                        EnsureAuthOrThrow(rr);
-                        var rep = await ReadJson<KcRoleRep>(rr, ct) ?? new KcRoleRep { Name = roleName };
-                        rep.ClientRole = true;
-                        rep.ContainerId = srcClient.Id;
-
-                        using var mapResp = await PostJsonWithFallback(http, mapNewBase, mapLegacyBase, new[] { rep }, ct);
-                        EnsureAuthOrThrow(mapResp);
-                        await AuditAsync("service-account:role-assign", realm, $"{newClientUuid}:{srcClientId}:{roleName}", ct);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new InvalidOperationException($"Сервисная роль '{roleName}' клиента '{srcClientId}' не назначена: {ex.Message}", ex);
-                    }
-                }
-            }
-        }
-
-        // ======= HTTP helpers (new → legacy fallback) =======
-
-        private static async Task<HttpResponseMessage> GetAsyncWithFallback(HttpClient http, string newUrl, string legacyUrl, CancellationToken ct)
-        {
-            var resp = await http.GetAsync(newUrl, ct);
-            if (resp.StatusCode == HttpStatusCode.NotFound)
-            {
-                resp.Dispose();
-                resp = await http.GetAsync(legacyUrl, ct);
-            }
-            return resp;
-        }
-
-        private static async Task<HttpResponseMessage> PostJsonWithFallback(HttpClient http, string newUrl, string legacyUrl, object body, CancellationToken ct)
-        {
-            var resp = await http.PostAsJsonAsync(newUrl, body, JsonOpts, ct);
-            if (resp.StatusCode == HttpStatusCode.NotFound)
-            {
-                resp.Dispose();
-                resp = await http.PostAsJsonAsync(legacyUrl, body, JsonOpts, ct);
-            }
-            return resp;
-        }
-
-        private static async Task<HttpResponseMessage> PutJsonWithFallback(HttpClient http, string newUrl, string legacyUrl, object body, CancellationToken ct)
-        {
-            var resp = await http.PutAsJsonAsync(newUrl, body, JsonOpts, ct);
-            if (resp.StatusCode == HttpStatusCode.NotFound)
-            {
-                resp.Dispose();
-                resp = await http.PutAsJsonAsync(legacyUrl, body, JsonOpts, ct);
-            }
-            return resp;
-        }
-
-        private static async Task<HttpResponseMessage> PostWithFallback(HttpClient http, string newUrl, string legacyUrl, CancellationToken ct)
-        {
-            var resp = await http.PostAsync(newUrl, null, ct);
-            if (resp.StatusCode == HttpStatusCode.NotFound)
-            {
-                resp.Dispose();
-                resp = await http.PostAsync(legacyUrl, null, ct);
-            }
-            return resp;
-        }
-
-        private static async Task<HttpResponseMessage> DeleteWithFallback(HttpClient http, string newUrl, string legacyUrl, CancellationToken ct)
-        {
-            var resp = await http.DeleteAsync(newUrl, ct);
-            if (resp.StatusCode == HttpStatusCode.NotFound)
-            {
-                resp.Dispose();
-                resp = await http.DeleteAsync(legacyUrl, ct);
-            }
-            return resp;
-        }
-
-        private static void EnsureAuthOrThrow(HttpResponseMessage resp)
-        {
-            if (resp.StatusCode == HttpStatusCode.Forbidden)
-                throw new UnauthorizedAccessException("Недостаточно прав для операции (нужны права realm-management).");
-
-            if (resp.StatusCode == HttpStatusCode.BadRequest)
-            {
-                var body = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-                throw new InvalidOperationException($"Запрос отклонён (400). Детали: {body}");
-            }
-
-            resp.EnsureSuccessStatusCode();
-        }
-
-        private static async Task<T?> ReadJson<T>(HttpResponseMessage resp, CancellationToken ct)
-            => await resp.Content.ReadFromJsonAsync<T>(JsonOpts, ct);
     }
+
+    private async Task<List<(string ClientId, string Role)>> GetServiceAccountRolesAsync(string realm, string clientUuid, CancellationToken ct)
+    {
+        var http = CreateAdminClient();
+
+        var getSvcUserNew = $"{BaseUrl}/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/service-account-user";
+        var getSvcUserLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/clients/{UR(clientUuid)}/service-account-user";
+
+        using var userResp = await http.GetWithLegacyFallbackAsync(getSvcUserNew, getSvcUserLegacy, ct);
+        userResp.EnsureAdminSuccess();
+        var svcUser = await ReadJsonAsync<KcUserRep>(userResp, ct);
+        if (svcUser?.Id == null)
+        {
+            return new List<(string, string)>();
+        }
+
+        var mapUrlNew = $"{BaseUrl}/admin/realms/{UR(realm)}/users/{UR(svcUser.Id)}/role-mappings";
+        var mapUrlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(realm)}/users/{UR(svcUser.Id)}/role-mappings";
+
+        using var mapResp = await http.GetWithLegacyFallbackAsync(mapUrlNew, mapUrlLegacy, ct);
+        mapResp.EnsureAdminSuccess();
+        var mappings = await ReadJsonAsync<RoleMappingsRep>(mapResp, ct);
+
+        var list = new List<(string ClientId, string Role)>();
+        if (mappings?.ClientMappings != null)
+        {
+            foreach (var kv in mappings.ClientMappings)
+            {
+                var roles = kv.Value.Mappings;
+                if (roles == null)
+                {
+                    continue;
+                }
+
+                foreach (var role in roles)
+                {
+                    if (!string.IsNullOrWhiteSpace(role.Name))
+                    {
+                        list.Add((kv.Key, role.Name!));
+                    }
+                }
+            }
+        }
+
+        return list;
+    }
+
+    private static List<ClientShort> FilterExcluded(IEnumerable<ClientShort> source, ISet<string> excluded)
+    {
+        if (excluded.Count == 0)
+        {
+            return source as List<ClientShort> ?? source.ToList();
+        }
+
+        return source.Where(c => !excluded.Contains(c.ClientId)).ToList();
+    }
+
+    private static async Task<T?> ReadJsonAsync<T>(HttpResponseMessage resp, CancellationToken ct)
+        => await resp.Content.ReadFromJsonAsync<T>(JsonOpts, ct);
 }

--- a/KeyCloak/EventsService.cs
+++ b/KeyCloak/EventsService.cs
@@ -1,98 +1,82 @@
-using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using Microsoft.Extensions.Options;
 
-namespace Assistant.KeyCloak
+namespace Assistant.KeyCloak;
+
+public sealed record EventEntry(string Type, DateTime At, string? User, string? Ip);
+
+internal sealed class EventRep
 {
-    public sealed record EventEntry(string Type, DateTime At, string? User, string? Ip);
+    public string? Type { get; set; }
+    public long? Time { get; set; }
+    public string? ClientId { get; set; }
+    public string? UserId { get; set; }
+    public string? Username { get; set; }
+    public string? IpAddress { get; set; }
+}
 
-    internal sealed class EventRep
+internal sealed class EventConfigRep
+{
+    public List<string>? EnabledEventTypes { get; set; }
+}
+
+public class EventsService
+{
+    private readonly IHttpClientFactory _factory;
+    private readonly AdminApiOptions _opt;
+
+    public EventsService(IHttpClientFactory factory, IOptions<AdminApiOptions> opt)
     {
-        public string? Type { get; set; }
-        public long? Time { get; set; }
-        public string? ClientId { get; set; }
-        public string? UserId { get; set; }
-        public string? Username { get; set; }
-        public string? IpAddress { get; set; }
+        _factory = factory;
+        _opt = opt.Value;
     }
 
-    internal sealed class EventConfigRep
+    private string BaseUrl => _opt.BaseUrl.TrimEnd('/');
+
+    public async Task<List<string>> GetEventTypesAsync(string realm, CancellationToken ct = default)
     {
-        public List<string>? EnabledEventTypes { get; set; }
+        var http = _factory.CreateClient("kc-admin");
+        var urlNew = $"{BaseUrl}/admin/realms/{Uri.EscapeDataString(realm)}/events/config";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{Uri.EscapeDataString(realm)}/events/config";
+
+        using var resp = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp.EnsureAdminSuccess();
+        var cfg = await resp.Content.ReadFromJsonAsync<EventConfigRep>(cancellationToken: ct);
+        return cfg?.EnabledEventTypes ?? new List<string>();
     }
 
-    public class EventsService
+    public async Task<List<EventEntry>> GetEventsAsync(
+        string realm,
+        string clientId,
+        string? type,
+        DateTime? from,
+        DateTime? to,
+        string? user,
+        string? ip,
+        int max = 50,
+        CancellationToken ct = default)
     {
-        private readonly IHttpClientFactory _factory;
-        private readonly AdminApiOptions _opt;
+        var http = _factory.CreateClient("kc-admin");
+        var qs = new List<string> { $"client={Uri.EscapeDataString(clientId)}", $"max={max}", "first=0" };
+        if (!string.IsNullOrWhiteSpace(type)) qs.Add($"type={Uri.EscapeDataString(type)}");
+        if (!string.IsNullOrWhiteSpace(user)) qs.Add($"user={Uri.EscapeDataString(user)}");
+        if (!string.IsNullOrWhiteSpace(ip)) qs.Add($"ipAddress={Uri.EscapeDataString(ip)}");
+        if (from.HasValue) qs.Add($"dateFrom={new DateTimeOffset(from.Value).ToUnixTimeMilliseconds()}");
+        if (to.HasValue) qs.Add($"dateTo={new DateTimeOffset(to.Value).ToUnixTimeMilliseconds()}");
+        var query = string.Join('&', qs);
+        var urlNew = $"{BaseUrl}/admin/realms/{Uri.EscapeDataString(realm)}/events?{query}";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{Uri.EscapeDataString(realm)}/events?{query}";
 
-        public EventsService(IHttpClientFactory factory, IOptions<AdminApiOptions> opt)
-        {
-            _factory = factory;
-            _opt = opt.Value;
-        }
-
-        private string BaseUrl => _opt.BaseUrl.TrimEnd('/');
-
-        public async Task<List<string>> GetEventTypesAsync(string realm, CancellationToken ct = default)
-        {
-            var http = _factory.CreateClient("kc-admin");
-            var urlNew = $"{BaseUrl}/admin/realms/{Uri.EscapeDataString(realm)}/events/config";
-            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{Uri.EscapeDataString(realm)}/events/config";
-            using var resp = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var cfg = await resp.Content.ReadFromJsonAsync<EventConfigRep>(cancellationToken: ct);
-            return cfg?.EnabledEventTypes ?? new List<string>();
-        }
-
-        public async Task<List<EventEntry>> GetEventsAsync(string realm, string clientId, string? type,
-            DateTime? from, DateTime? to, string? user, string? ip, int max = 50, CancellationToken ct = default)
-        {
-            var http = _factory.CreateClient("kc-admin");
-            var qs = new List<string> { $"client={Uri.EscapeDataString(clientId)}", $"max={max}", "first=0" };
-            if (!string.IsNullOrWhiteSpace(type)) qs.Add($"type={Uri.EscapeDataString(type)}");
-            if (!string.IsNullOrWhiteSpace(user)) qs.Add($"user={Uri.EscapeDataString(user)}");
-            if (!string.IsNullOrWhiteSpace(ip)) qs.Add($"ipAddress={Uri.EscapeDataString(ip)}");
-            if (from.HasValue) qs.Add($"dateFrom={new DateTimeOffset(from.Value).ToUnixTimeMilliseconds()}");
-            if (to.HasValue) qs.Add($"dateTo={new DateTimeOffset(to.Value).ToUnixTimeMilliseconds()}");
-            var query = string.Join('&', qs);
-            var urlNew = $"{BaseUrl}/admin/realms/{Uri.EscapeDataString(realm)}/events?{query}";
-            var urlLegacy = $"{BaseUrl}/auth/admin/realms/{Uri.EscapeDataString(realm)}/events?{query}";
-            using var resp = await GetAsyncWithFallback(http, urlNew, urlLegacy, ct);
-            EnsureAuthOrThrow(resp);
-            var reps = await resp.Content.ReadFromJsonAsync<List<EventRep>>(cancellationToken: ct) ?? new();
-            return reps
-                .Where(r => string.Equals(r.ClientId, clientId, StringComparison.OrdinalIgnoreCase))
-                .Select(r => new EventEntry(
-                    r.Type ?? string.Empty,
-                    DateTimeOffset.FromUnixTimeMilliseconds(r.Time ?? 0).LocalDateTime,
-                    r.Username ?? r.UserId,
-                    r.IpAddress))
-                .ToList();
-        }
-
-        private static async Task<HttpResponseMessage> GetAsyncWithFallback(HttpClient http, string newUrl, string legacyUrl, CancellationToken ct)
-        {
-            var resp = await http.GetAsync(newUrl, ct);
-            if (resp.StatusCode == HttpStatusCode.NotFound)
-            {
-                resp.Dispose();
-                resp = await http.GetAsync(legacyUrl, ct);
-            }
-            return resp;
-        }
-
-        private static void EnsureAuthOrThrow(HttpResponseMessage resp)
-        {
-            if (resp.StatusCode == HttpStatusCode.Forbidden)
-                throw new UnauthorizedAccessException("Недостаточно прав для операции (нужны права realm-management).");
-            if (resp.StatusCode == HttpStatusCode.BadRequest)
-            {
-                var body = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-                throw new InvalidOperationException($"Запрос отклонён (400). Детали: {body}");
-            }
-            resp.EnsureSuccessStatusCode();
-        }
+        using var resp = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp.EnsureAdminSuccess();
+        var reps = await resp.Content.ReadFromJsonAsync<List<EventRep>>(cancellationToken: ct) ?? new List<EventRep>();
+        return reps
+            .Where(r => string.Equals(r.ClientId, clientId, StringComparison.OrdinalIgnoreCase))
+            .Select(r => new EventEntry(
+                r.Type ?? string.Empty,
+                DateTimeOffset.FromUnixTimeMilliseconds(r.Time ?? 0).LocalDateTime,
+                r.Username ?? r.UserId,
+                r.IpAddress))
+            .ToList();
     }
 }

--- a/KeyCloak/KeycloakAdminHttpClientExtensions.cs
+++ b/KeyCloak/KeycloakAdminHttpClientExtensions.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Assistant.KeyCloak;
+
+internal static class KeycloakAdminHttpClientExtensions
+{
+    public static async Task<HttpResponseMessage> GetWithLegacyFallbackAsync(
+        this HttpClient http,
+        string modernUrl,
+        string legacyUrl,
+        CancellationToken ct)
+        => await SendWithFallbackAsync(http, modernUrl, legacyUrl, static (client, url, token) => client.GetAsync(url, token), ct);
+
+    public static async Task<HttpResponseMessage> PostJsonWithLegacyFallbackAsync<T>(
+        this HttpClient http,
+        string modernUrl,
+        string legacyUrl,
+        T body,
+        JsonSerializerOptions serializerOptions,
+        CancellationToken ct)
+        => await SendWithFallbackAsync(http, modernUrl, legacyUrl,
+            (client, url, token) => client.PostAsJsonAsync(url, body, serializerOptions, token), ct);
+
+    public static async Task<HttpResponseMessage> PutJsonWithLegacyFallbackAsync<T>(
+        this HttpClient http,
+        string modernUrl,
+        string legacyUrl,
+        T body,
+        JsonSerializerOptions serializerOptions,
+        CancellationToken ct)
+        => await SendWithFallbackAsync(http, modernUrl, legacyUrl,
+            (client, url, token) => client.PutAsJsonAsync(url, body, serializerOptions, token), ct);
+
+    public static async Task<HttpResponseMessage> PostWithLegacyFallbackAsync(
+        this HttpClient http,
+        string modernUrl,
+        string legacyUrl,
+        CancellationToken ct)
+        => await SendWithFallbackAsync(http, modernUrl, legacyUrl,
+            static (client, url, token) => client.PostAsync(url, content: null, token), ct);
+
+    public static async Task<HttpResponseMessage> DeleteWithLegacyFallbackAsync(
+        this HttpClient http,
+        string modernUrl,
+        string legacyUrl,
+        CancellationToken ct)
+        => await SendWithFallbackAsync(http, modernUrl, legacyUrl, static (client, url, token) => client.DeleteAsync(url, token), ct);
+
+    public static void EnsureAdminSuccess(this HttpResponseMessage response)
+    {
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            throw new UnauthorizedAccessException("Недостаточно прав для операции (нужны права realm-management).");
+        }
+
+        if (response.StatusCode == HttpStatusCode.BadRequest)
+        {
+            var body = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            throw new InvalidOperationException($"Запрос отклонён (400). Детали: {body}");
+        }
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    private static async Task<HttpResponseMessage> SendWithFallbackAsync(
+        HttpClient http,
+        string modernUrl,
+        string legacyUrl,
+        Func<HttpClient, string, CancellationToken, Task<HttpResponseMessage>> sender,
+        CancellationToken ct)
+    {
+        var response = await sender(http, modernUrl, ct);
+        if (response.StatusCode != HttpStatusCode.NotFound)
+        {
+            return response;
+        }
+
+        response.Dispose();
+        return await sender(http, legacyUrl, ct);
+    }
+}

--- a/KeyCloak/Models/ClientModels.cs
+++ b/KeyCloak/Models/ClientModels.cs
@@ -1,0 +1,45 @@
+namespace Assistant.KeyCloak.Models;
+
+public sealed record ClientShort(string Id, string ClientId);
+
+public sealed record ClientDetails(
+    string Id,
+    string ClientId,
+    bool Enabled,
+    string? Description,
+    bool ClientAuth,
+    bool StandardFlow,
+    bool ServiceAccount,
+    IReadOnlyList<string> RedirectUris,
+    IReadOnlyList<string> LocalRoles,
+    IReadOnlyList<(string ClientId, string Role)> ServiceRoles,
+    IReadOnlyList<string> DefaultScopes
+);
+
+public sealed record RoleHit(string ClientUuid, string ClientId, string Role);
+
+public sealed record NewClientSpec(
+    string Realm,
+    string ClientId,
+    string? Description,
+    bool ClientAuthentication,
+    bool StandardFlow,
+    bool ServiceAccount,
+    IReadOnlyList<string> RedirectUris,
+    IReadOnlyList<string> LocalRoles,
+    IReadOnlyList<(string ClientId, string Role)> ServiceRoles
+);
+
+public sealed record UpdateClientSpec(
+    string Realm,
+    string CurrentClientId,
+    string ClientId,
+    bool Enabled,
+    string? Description,
+    bool ClientAuth,
+    bool StandardFlow,
+    bool ServiceAccount,
+    IReadOnlyList<string> RedirectUris,
+    IReadOnlyList<string> LocalRoles,
+    IReadOnlyList<(string ClientId, string Role)> ServiceRoles
+);

--- a/KeyCloak/RealmsService.cs
+++ b/KeyCloak/RealmsService.cs
@@ -1,98 +1,95 @@
-﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using System.Net;
 using System.Text.Json;
 
-namespace Assistant.KeyCloak
+namespace Assistant.KeyCloak;
+
+public class RealmRepresentation
 {
-    public class RealmRepresentation
+    public string? Id { get; set; }
+    public string? Realm { get; set; }
+    public string? DisplayName { get; set; }
+    public bool? Enabled { get; set; }
+}
+
+public class RealmsService
+{
+    private readonly IHttpClientFactory _factory;
+    private readonly AdminApiOptions _opt;
+    private readonly IMemoryCache _cache;
+
+    private const string CacheKey = "kc:realms:list";
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(30);
+    private static readonly SemaphoreSlim RefreshLock = new(1, 1);
+
+    public RealmsService(IHttpClientFactory factory, IOptions<AdminApiOptions> opt, IMemoryCache cache)
     {
-        public string? Id { get; set; }
-        public string? Realm { get; set; }
-        public string? DisplayName { get; set; }
-        public bool? Enabled { get; set; }
+        _factory = factory;
+        _opt = opt.Value;
+        _cache = cache;
     }
 
-    public class RealmsService
-    {
-        private readonly IHttpClientFactory _factory;
-        private readonly AdminApiOptions _opt;
-        private readonly IMemoryCache _cache;
-
-        private const string CacheKey = "kc:realms:list";
-        private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(30);
-        private static readonly SemaphoreSlim _refreshLock = new(1, 1);
-
-        public RealmsService(IHttpClientFactory factory, IOptions<AdminApiOptions> opt, IMemoryCache cache)
+    public Task<List<RealmRepresentation>> GetRealmsAsync(CancellationToken ct = default)
+        => _cache.GetOrCreateAsync(CacheKey, async entry =>
         {
-            _factory = factory;
-            _opt = opt.Value;
-            _cache = cache;
-        }
+            entry.AbsoluteExpirationRelativeToNow = CacheTtl;
+            return await FetchRealmsAsync(ct);
+        })!;
 
-        public Task<List<RealmRepresentation>> GetRealmsAsync(CancellationToken ct = default)
-            => _cache.GetOrCreateAsync(CacheKey, async entry =>
+    public async Task<bool> RealmExistsAsync(string realm, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(realm)) return false;
+
+        var cached = await GetRealmsAsync(ct);
+        if (cached.Any(r => string.Equals(r.Realm, realm, StringComparison.OrdinalIgnoreCase)))
+            return true;
+
+        await RefreshRealmsAsync(force: true, ct);
+        var fresh = await GetRealmsAsync(ct);
+        return fresh.Any(r => string.Equals(r.Realm, realm, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public async Task RefreshRealmsAsync(bool force = false, CancellationToken ct = default)
+    {
+        await RefreshLock.WaitAsync(ct);
+        try
+        {
+            if (force) _cache.Remove(CacheKey);
+
+            await _cache.GetOrCreateAsync(CacheKey, async entry =>
             {
                 entry.AbsoluteExpirationRelativeToNow = CacheTtl;
                 return await FetchRealmsAsync(ct);
             })!;
-
-        public async Task<bool> RealmExistsAsync(string realm, CancellationToken ct = default)
+        }
+        finally
         {
-            if (string.IsNullOrWhiteSpace(realm)) return false;
+            RefreshLock.Release();
+        }
+    }
 
-            var cached = await GetRealmsAsync(ct);
-            if (cached.Any(r => string.Equals(r.Realm, realm, StringComparison.OrdinalIgnoreCase)))
-                return true;
+    private async Task<List<RealmRepresentation>> FetchRealmsAsync(CancellationToken ct)
+    {
+        var http = _factory.CreateClient("kc-admin");
+        var baseUrl = _opt.BaseUrl.TrimEnd('/');
 
-            await RefreshRealmsAsync(force: true, ct);
-            var fresh = await GetRealmsAsync(ct);
-            return fresh.Any(r => string.Equals(r.Realm, realm, StringComparison.OrdinalIgnoreCase));
+        var urlNew = $"{baseUrl}/admin/realms?briefRepresentation=true";
+        var urlLegacy = $"{baseUrl}/auth/admin/realms?briefRepresentation=true";
+
+        using var resp = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+        {
+            throw new UnauthorizedAccessException("Недостаточно прав для чтения реалмов (нужны роли realm-management: view-realm/realm-admin).");
         }
 
-        public async Task RefreshRealmsAsync(bool force = false, CancellationToken ct = default)
-        {
-            await _refreshLock.WaitAsync(ct);
-            try
-            {
-                if (force) _cache.Remove(CacheKey);
+        resp.EnsureSuccessStatusCode();
 
-                await _cache.GetOrCreateAsync(CacheKey, async entry =>
-                {
-                    entry.AbsoluteExpirationRelativeToNow = CacheTtl;
-                    return await FetchRealmsAsync(ct);
-                })!;
-            }
-            finally
-            {
-                _refreshLock.Release();
-            }
-        }
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var list = await resp.Content.ReadFromJsonAsync<List<RealmRepresentation>>(options, ct)
+                   ?? new List<RealmRepresentation>();
 
-        private async Task<List<RealmRepresentation>> FetchRealmsAsync(CancellationToken ct)
-        {
-            var http = _factory.CreateClient("kc-admin");
-            var baseUrl = _opt.BaseUrl.TrimEnd('/');
-
-            var url = $"{baseUrl}/admin/realms?briefRepresentation=true";
-            var resp = await http.GetAsync(url, ct);
-
-            if (resp.StatusCode == HttpStatusCode.NotFound)
-            {
-                var legacy = $"{baseUrl}/auth/admin/realms?briefRepresentation=true";
-                resp = await http.GetAsync(legacy, ct);
-            }
-
-            if (resp.StatusCode == HttpStatusCode.Forbidden)
-                throw new UnauthorizedAccessException("Недостаточно прав для чтения реалмов (нужны роли realm-management: view-realm/realm-admin).");
-
-            resp.EnsureSuccessStatusCode();
-
-            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var list = await resp.Content.ReadFromJsonAsync<List<RealmRepresentation>>(options, ct)
-                       ?? new List<RealmRepresentation>();
-
-            return list.Where(r => !string.IsNullOrWhiteSpace(r.Realm)).OrderBy(r => r.Realm, StringComparer.OrdinalIgnoreCase).ToList();
-        }
+        return list.Where(r => !string.IsNullOrWhiteSpace(r.Realm)).OrderBy(r => r.Realm, StringComparer.OrdinalIgnoreCase).ToList();
     }
 }

--- a/Pages/Clients/ClientFormUtilities.cs
+++ b/Pages/Clients/ClientFormUtilities.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Assistant.Pages.Clients;
+
+internal static class ClientFormUtilities
+{
+    private static readonly Regex RoleNameRegex = new("^[a-z][a-z0-9._:-]{2,63}$", RegexOptions.Compiled);
+    private static readonly Regex ClientIdRegex = new("^[a-z0-9][a-z0-9-]{2,60}$", RegexOptions.Compiled);
+
+    public static List<string> ParseStringList(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new List<string>();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json!) ?? new List<string>();
+        }
+        catch
+        {
+            return new List<string>();
+        }
+    }
+
+    public static List<string> NormalizeDistinct(IEnumerable<string> items)
+        => items
+            .Select(static s => (s ?? string.Empty).Trim())
+            .Where(static s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    public static bool IsValidHttpUrl(string url)
+        => Uri.TryCreate(url, UriKind.Absolute, out var uri)
+           && (uri.Scheme == Uri.UriSchemeHttps
+               || (uri.Scheme == Uri.UriSchemeHttp
+                   && (uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+                       || IPAddress.TryParse(uri.Host, out _))));
+
+    public static bool TryValidateRedirectTemplate(string redirectUri)
+    {
+        var starPos = redirectUri.IndexOf('*');
+        if (starPos < 0)
+        {
+            return true;
+        }
+
+        if (starPos != redirectUri.Length - 1 || starPos == 0 || redirectUri[starPos - 1] != '/')
+        {
+            return false;
+        }
+
+        return Uri.TryCreate(redirectUri[..starPos], UriKind.Absolute, out _);
+    }
+
+    public static IEnumerable<string> ValidateRedirects(IEnumerable<string> redirects)
+    {
+        foreach (var redirect in redirects)
+        {
+            if (!TryValidateRedirectTemplate(redirect))
+            {
+                yield return redirect;
+                continue;
+            }
+
+            var candidate = redirect.Replace("*", string.Empty, StringComparison.Ordinal);
+            if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri)
+                || !string.IsNullOrEmpty(uri.Fragment)
+                || !(uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
+                     || (uri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase)
+                         && (uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+                             || IPAddress.TryParse(uri.Host, out _)))))
+            {
+                yield return redirect;
+            }
+        }
+    }
+
+    public static List<(string ClientId, string Role)> ParseServiceRolePairs(string? json)
+    {
+        var result = new List<(string, string)>();
+        foreach (var value in ParseStringList(json))
+        {
+            var parts = value.Split(':', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            var clientId = parts[0].Trim();
+            var role = parts[1].Trim();
+            if (!string.IsNullOrWhiteSpace(clientId) && !string.IsNullOrWhiteSpace(role))
+            {
+                result.Add((clientId, role));
+            }
+        }
+
+        return result;
+    }
+
+    public static IEnumerable<string> FindInvalidLocalRoles(IEnumerable<string> localRoles)
+        => localRoles.Where(role => !RoleNameRegex.IsMatch(role));
+
+    public static IEnumerable<string> FindInvalidServiceRoleEntries(IEnumerable<string> entries, ISet<string> restrictedClients)
+    {
+        foreach (var entry in entries)
+        {
+            var separatorIndex = entry.IndexOf(':');
+            if (separatorIndex <= 0 || separatorIndex >= entry.Length - 1)
+            {
+                yield return entry;
+                continue;
+            }
+
+            var client = entry[..separatorIndex].Trim();
+            var role = entry[(separatorIndex + 1)..].Trim();
+
+            if (!ClientIdRegex.IsMatch(client) || !RoleNameRegex.IsMatch(role) || restrictedClients.Contains(client))
+            {
+                yield return entry;
+            }
+        }
+    }
+}

--- a/Pages/Clients/Create.cshtml.cs
+++ b/Pages/Clients/Create.cshtml.cs
@@ -1,302 +1,242 @@
-﻿using Assistant.KeyCloak;
+using Assistant.KeyCloak;
+using Assistant.KeyCloak.Models;
 using Assistant.Interfaces;
 using Assistant.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using System.Net;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using System.Collections.Generic;
 
-namespace Assistant.Pages.Clients
+namespace Assistant.Pages.Clients;
+
+public class CreateModel : PageModel
 {
-    public class CreateModel : PageModel
+    private readonly RealmsService _realms;
+    private readonly ClientsService _clients;
+    private readonly UserClientsRepository _repo;
+    private readonly ServiceRoleExclusionsRepository _exclusions;
+
+    public CreateModel(
+        RealmsService realms,
+        ClientsService clients,
+        UserClientsRepository repo,
+        ServiceRoleExclusionsRepository exclusions)
     {
-        private readonly RealmsService _realms;
-        private readonly ClientsService _clients;
-        private readonly UserClientsRepository _repo;
-        private readonly ServiceRoleExclusionsRepository _exclusions;
+        _realms = realms;
+        _clients = clients;
+        _repo = repo;
+        _exclusions = exclusions;
+    }
 
-        public CreateModel(
-            RealmsService realms,
-            ClientsService clients,
-            UserClientsRepository repo,
-            ServiceRoleExclusionsRepository exclusions)
+    public int StepToShow { get; set; }
+
+    [BindProperty] public string? Realm { get; set; }
+    public List<SelectListItem> RealmOptions { get; private set; } = new();
+    public string RealmMapJson { get; private set; } = "{}";
+
+    [BindProperty] public string? ClientId { get; set; }
+    [BindProperty] public string? Description { get; set; }
+    [BindProperty] public bool ClientAuth { get; set; }
+    [BindProperty] public bool FlowStandard { get; set; }
+    [BindProperty] public bool FlowService { get; set; }
+
+    [BindProperty] public string? RedirectUrisJson { get; set; }
+    [BindProperty] public string? LocalRolesJson { get; set; }
+    [BindProperty] public string? ServiceRolesJson { get; set; }
+
+    [BindProperty] public string? AppName { get; set; }
+    [BindProperty] public string? AppUrl { get; set; }
+    [BindProperty] public string? ServiceOwner { get; set; }
+    [BindProperty] public string? ServiceManager { get; set; }
+
+    public async Task OnGet() => await LoadViewDataAsync();
+
+    private static bool IsValidClientId(string? id)
+    {
+        if (string.IsNullOrWhiteSpace(id)) return false;
+        if (id.Length < 10 || id.Length > 80) return false;
+        if (!id.StartsWith("app-bank-", StringComparison.OrdinalIgnoreCase)) return false;
+        var slug = id["app-bank-".Length..];
+        return Regex.IsMatch(slug, "^[a-z0-9-]+$", RegexOptions.IgnoreCase);
+    }
+
+    private static int DetermineStepFromErrors(ModelStateDictionary modelState)
+    {
+        var min = int.MaxValue;
+        foreach (var entry in modelState)
         {
-            _realms = realms;
-            _clients = clients;
-            _repo = repo;
-            _exclusions = exclusions;
+            if (entry.Value?.Errors?.Count > 0)
+            {
+                var key = entry.Key ?? string.Empty;
+                min = Math.Min(min, MapFieldToStep(key));
+            }
         }
 
-        public int StepToShow { get; set; } = 0;
+        return min == int.MaxValue ? 1 : min;
+    }
 
-        [BindProperty] public string? Realm { get; set; }
-        public List<SelectListItem> RealmOptions { get; private set; } = new();
-        public string RealmMapJson { get; private set; } = "{}";
+    private static int MapFieldToStep(string key)
+    {
+        bool Hit(string name) =>
+            key.Equals(name, StringComparison.OrdinalIgnoreCase)
+            || key.StartsWith(name + "[", StringComparison.OrdinalIgnoreCase)
+            || key.Equals(name + "Json", StringComparison.OrdinalIgnoreCase);
 
-        [BindProperty] public string? ClientId { get; set; }
-        [BindProperty] public string? Description { get; set; }
-        [BindProperty] public bool ClientAuth { get; set; }
-        [BindProperty] public bool FlowStandard { get; set; }
-        [BindProperty] public bool FlowService { get; set; }
+        if (Hit(nameof(Realm))) return 1;
+        if (Hit(nameof(ClientId)) || Hit(nameof(Description))) return 2;
+        if (Hit(nameof(AppName)) || Hit(nameof(AppUrl)) || Hit(nameof(ServiceOwner)) || Hit(nameof(ServiceManager))) return 3;
+        if (Hit(nameof(ClientAuth)) || Hit(nameof(FlowStandard)) || Hit(nameof(FlowService))) return 4;
+        if (Hit(nameof(RedirectUrisJson))) return 5;
+        if (Hit(nameof(LocalRolesJson))) return 6;
+        if (Hit(nameof(ServiceRolesJson))) return 7;
+        return 1;
+    }
 
-        [BindProperty] public string? RedirectUrisJson { get; set; }
-        [BindProperty] public string? LocalRolesJson { get; set; }
-        [BindProperty] public string? ServiceRolesJson { get; set; }
-
-        [BindProperty] public string? AppName { get; set; }       // Название АС (обяз.)
-        [BindProperty] public string? AppUrl { get; set; }        // Ссылка на АС
-        [BindProperty] public string? ServiceOwner { get; set; }  // Владелец сервиса
-        [BindProperty] public string? ServiceManager { get; set; }// Менеджер сервиса
-
-        public async Task OnGet() => await LoadViewDataAsync();
-
-        // ===== helpers =====
-        private static List<string> NormalizeList(IEnumerable<string> items)
-            => items.Select(s => (s ?? "").Trim())
-                    .Where(s => !string.IsNullOrEmpty(s))
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToList();
-
-        private static bool IsValidClientId(string? id)
+    private async Task LoadViewDataAsync()
+    {
+        var names = await _realms.GetRealmsAsync();
+        if (User.IsInRole("assistant-user") && !User.IsInRole("assistant-admin"))
         {
-            if (string.IsNullOrWhiteSpace(id)) return false;
-            if (id.Length < 10 || id.Length > 80) return false;
-            if (!id.StartsWith("app-bank-", StringComparison.OrdinalIgnoreCase)) return false;
-            var slug = id["app-bank-".Length..];
-            return Regex.IsMatch(slug, "^[a-z0-9-]+$", RegexOptions.IgnoreCase);
+            names = names.Where(n => !string.Equals(n.Realm, "master", StringComparison.OrdinalIgnoreCase)).ToList();
         }
 
-        private static int DetermineStepFromErrors(ModelStateDictionary ms)
+        RealmOptions = names.Select(n => new SelectListItem { Value = n.Realm, Text = n.Realm }).ToList();
+        Realm ??= RealmOptions.FirstOrDefault()?.Value;
+        var dict = names.ToDictionary(r => r.Realm, r => r.DisplayName ?? string.Empty);
+        RealmMapJson = JsonSerializer.Serialize(dict);
+    }
+
+    public async Task<IActionResult> OnGetRoleLookupAsync(string realm, string q, int clientFirst = 0, int clientsToScan = 25, int rolesPerClient = 10, CancellationToken ct = default)
+    {
+        var (hits, next) = await _clients.FindRolesAcrossClientsAsync(realm, q, clientFirst, clientsToScan, rolesPerClient, ct);
+        return new JsonResult(new { hits, nextClientFirst = next });
+    }
+
+    public async Task<IActionResult> OnGetClientsSearchAsync(string realm, string q, int first = 0, int max = 20, CancellationToken ct = default)
+        => new JsonResult(await _clients.SearchClientsAsync(realm, q ?? string.Empty, first, max, ct));
+
+    public async Task<IActionResult> OnGetClientRolesAsync(string realm, string id, int first = 0, int max = 50, string? q = null, CancellationToken ct = default)
+        => new JsonResult(await _clients.GetClientRolesAsync(realm, id, first, max, q, ct));
+
+    public async Task<IActionResult> OnPostCreate(CancellationToken ct)
+    {
+        await LoadViewDataAsync();
+
+        if (string.IsNullOrWhiteSpace(Realm))
         {
-            int min = int.MaxValue;
-            foreach (var kv in ms)
-            {
-                if (kv.Value?.Errors?.Count > 0)
-                {
-                    var key = kv.Key ?? string.Empty;
-                    min = Math.Min(min, MapFieldToStep(key));
-                }
-            }
-            return (min == int.MaxValue) ? 1 : min;
+            ModelState.AddModelError(nameof(Realm), "Выберите realm.");
         }
 
-        private static int MapFieldToStep(string key)
+        if (!IsValidClientId(ClientId))
         {
-            bool Hit(string name) =>
-                key.Equals(name, StringComparison.OrdinalIgnoreCase)
-                || key.StartsWith(name + "[", StringComparison.OrdinalIgnoreCase)
-                || key.Equals(name + "Json", StringComparison.OrdinalIgnoreCase);
-
-            if (Hit(nameof(Realm))) return 1;                               // Step 1
-            if (Hit(nameof(ClientId)) || Hit(nameof(Description))) return 2; // Step 2
-            if (Hit(nameof(AppName)) || Hit(nameof(AppUrl)) ||
-                Hit(nameof(ServiceOwner)) || Hit(nameof(ServiceManager))) return 3; // Step 3
-            if (Hit(nameof(ClientAuth)) || Hit(nameof(FlowStandard)) || Hit(nameof(FlowService))) return 4; // Step 4
-            if (Hit(nameof(RedirectUrisJson))) return 5;                    // Step 5
-            if (Hit(nameof(LocalRolesJson))) return 6;                      // Step 6
-            if (Hit(nameof(ServiceRolesJson))) return 7;                    // Step 7
-            return 1;
+            ModelState.AddModelError(nameof(ClientId), "Client ID должен начинаться с 'app-bank-' и содержать латиницу/цифры/дефисы (10–80 символов).");
         }
 
-        private static bool IsValidHttpUrl(string url)
-            => Uri.TryCreate(url, UriKind.Absolute, out var u)
-               && (u.Scheme == Uri.UriSchemeHttps || u.Scheme == Uri.UriSchemeHttp);
-
-        private static List<string> TryParseList(string? json)
+        if (string.IsNullOrWhiteSpace(AppName) || AppName!.Trim().Length < 3)
         {
-            try
-            {
-                return string.IsNullOrWhiteSpace(json)
-                    ? new List<string>()
-                    : (JsonSerializer.Deserialize<List<string>>(json!) ?? new List<string>());
-            }
-            catch { return new List<string>(); }
+            ModelState.AddModelError(nameof(AppName), "Название АС обязательно (минимум 3 символа).");
         }
 
-        private async Task LoadViewDataAsync()
+        if (!string.IsNullOrWhiteSpace(AppUrl) && !ClientFormUtilities.IsValidHttpUrl(AppUrl!))
         {
-            var names = await _realms.GetRealmsAsync();
-            if (User.IsInRole("assistant-user") && !User.IsInRole("assistant-admin"))
-                names = names.Where(n => !string.Equals(n.Realm, "master", StringComparison.OrdinalIgnoreCase)).ToList();
-
-            RealmOptions = names.Select(n => new SelectListItem { Value = n.Realm, Text = n.Realm }).ToList();
-            Realm ??= RealmOptions.FirstOrDefault()?.Value;
-            var dict = names.ToDictionary(r => r.Realm, r => r.DisplayName ?? "");
-            RealmMapJson = JsonSerializer.Serialize(dict);
+            ModelState.AddModelError(nameof(AppUrl), "Укажите корректный http/https URL.");
         }
 
-        // ===== AJAX handlers для фронта Service Roles =====
-        public async Task<IActionResult> OnGetRoleLookupAsync(string realm, string q, int clientFirst = 0, int clientsToScan = 25, int rolesPerClient = 10, CancellationToken ct = default)
+        if (!await _realms.RealmExistsAsync(Realm ?? string.Empty))
         {
-            var (hits, next) = await _clients.FindRolesAcrossClientsAsync(realm, q, clientFirst, clientsToScan, rolesPerClient, ct);
-            return new JsonResult(new { hits, nextClientFirst = next });
+            ModelState.AddModelError(nameof(Realm), "Такого realm не существет.");
         }
 
-        public async Task<IActionResult> OnGetClientsSearchAsync(string realm, string q, int first = 0, int max = 20, CancellationToken ct = default)
-            => new JsonResult(await _clients.SearchClientsAsync(realm, q ?? "", first, max, ct));
-
-        public async Task<IActionResult> OnGetClientRolesAsync(string realm, string id, int first = 0, int max = 50, string? q = null, CancellationToken ct = default)
-            => new JsonResult(await _clients.GetClientRolesAsync(realm, id, first, max, q, ct));
-
-        // ===== Создание клиента =====
-        public async Task<IActionResult> OnPostCreate(CancellationToken ct)
+        if (!User.IsInRole("assistant-admin") && string.Equals(Realm, "master", StringComparison.OrdinalIgnoreCase))
         {
-            await LoadViewDataAsync(); // чтобы при ошибке повторно отрисовать селекты/описания
+            ModelState.AddModelError(nameof(Realm), "Realm 'master' недоступен.");
+        }
 
-            // 1) Базовая валидация
-            if (string.IsNullOrWhiteSpace(Realm))
-                ModelState.AddModelError(nameof(Realm), "Выберите realm.");
+        if (FlowService)
+        {
+            ClientAuth = true;
+        }
 
-            if (!IsValidClientId(ClientId))
-                ModelState.AddModelError(nameof(ClientId), "Client ID должен начинаться с 'app-bank-' и содержать латиницу/цифры/дефисы (10–80 символов).");
+        var redirects = ClientFormUtilities.NormalizeDistinct(ClientFormUtilities.ParseStringList(RedirectUrisJson));
+        RedirectUrisJson = JsonSerializer.Serialize(redirects);
+        var badRedirects = ClientFormUtilities.ValidateRedirects(redirects).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (badRedirects.Count > 0)
+        {
+            ModelState.AddModelError(nameof(RedirectUrisJson), $"Некорректные Redirect URI: {string.Join(", ", badRedirects)}");
+        }
 
-            if (string.IsNullOrWhiteSpace(AppName) || AppName!.Trim().Length < 3)
-                ModelState.AddModelError(nameof(AppName), "Название АС обязательно (минимум 3 символа).");
+        if (FlowStandard && redirects.Count == 0)
+        {
+            ModelState.AddModelError(nameof(RedirectUrisJson), "Для Standard flow требуется минимум один Redirect URI.");
+        }
 
-            if (!string.IsNullOrWhiteSpace(AppUrl) && !IsValidHttpUrl(AppUrl!))
-                ModelState.AddModelError(nameof(AppUrl), "Укажите корректный http/https URL.");
+        var locals = ClientFormUtilities.NormalizeDistinct(ClientFormUtilities.ParseStringList(LocalRolesJson));
+        LocalRolesJson = JsonSerializer.Serialize(locals);
+        var badLocal = ClientFormUtilities.FindInvalidLocalRoles(locals).ToList();
+        if (badLocal.Any())
+        {
+            ModelState.AddModelError(nameof(LocalRolesJson), $"Некорректные локальные роли: {string.Join(", ", badLocal)}");
+        }
 
-            if (!await _realms.RealmExistsAsync(Realm ?? ""))
-                ModelState.AddModelError(nameof(Realm), "Такого realm не существует.");
+        if (locals.Count > 10)
+        {
+            ModelState.AddModelError(nameof(LocalRolesJson), "Слишком много локальных ролей (максимум 10).");
+        }
 
-            if (!User.IsInRole("assistant-admin") && string.Equals(Realm, "master", StringComparison.OrdinalIgnoreCase))
-                ModelState.AddModelError(nameof(Realm), "Realm 'master' недоступен.");
+        var svcEntries = ClientFormUtilities.NormalizeDistinct(ClientFormUtilities.ParseStringList(ServiceRolesJson));
+        ServiceRolesJson = JsonSerializer.Serialize(svcEntries);
+        var restrictedClients = await _exclusions.GetAllAsync(ct);
+        var badSvc = ClientFormUtilities.FindInvalidServiceRoleEntries(svcEntries, restrictedClients).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (badSvc.Any())
+        {
+            ModelState.AddModelError(nameof(ServiceRolesJson), $"Некорректные сервисные роли: {string.Join(", ", badSvc)}");
+        }
 
-            // Service account => обязательно включаем Client Authentication
-            if (FlowService) ClientAuth = true;
+        if (!ModelState.IsValid)
+        {
+            StepToShow = DetermineStepFromErrors(ModelState);
+            return Page();
+        }
 
-            // 2) Redirect URIs
-            var redirects = NormalizeList(TryParseList(RedirectUrisJson));
-            var badRedirects = new List<string>();
-            foreach (var s in redirects)
+        var spec = new NewClientSpec(
+            Realm: Realm!,
+            ClientId: ClientId!,
+            Description: Description,
+            ClientAuthentication: ClientAuth,
+            StandardFlow: FlowStandard,
+            ServiceAccount: FlowService,
+            RedirectUris: redirects,
+            LocalRoles: locals,
+            ServiceRoles: ClientFormUtilities.ParseServiceRolePairs(ServiceRolesJson)
+        );
+
+        try
+        {
+            var createdId = await _clients.CreateClientAsync(spec, ct);
+
+            var summary = new ClientSummary(
+                Name: AppName ?? spec.ClientId,
+                ClientId: spec.ClientId,
+                Realm: spec.Realm,
+                Enabled: true,
+                FlowStandard: spec.StandardFlow,
+                FlowService: spec.ServiceAccount);
+            var username = User.Identity?.Name ?? string.Empty;
+            if (!string.IsNullOrEmpty(username))
             {
-                var candidate = s;
-                var starPos = s.IndexOf('*');
-                if (starPos >= 0)
-                {
-                    // Разрешаем шаблон типа https://host/path/*
-                    if (starPos != s.Length - 1 || starPos == 0 || s[starPos - 1] != '/')
-                    {
-                        badRedirects.Add(s);
-                        continue;
-                    }
-                    candidate = s[..starPos];
-                }
-
-                if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri))
-                {
-                    badRedirects.Add(s);
-                    continue;
-                }
-
-                var httpsOk = uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase);
-                var httpLocalOk = uri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase)
-                                  && (uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
-                                      || IPAddress.TryParse(uri.Host, out _));
-                if (!(httpsOk || httpLocalOk)) badRedirects.Add(s);
-                if (!string.IsNullOrEmpty(uri.Fragment)) badRedirects.Add(s);
-            }
-            if (badRedirects.Count > 0)
-                ModelState.AddModelError(nameof(RedirectUrisJson), $"Некорректные Redirect URI: {string.Join(", ", badRedirects.Distinct())}");
-
-            if (FlowStandard && redirects.Count == 0)
-                ModelState.AddModelError(nameof(RedirectUrisJson), "Для Standard flow требуется минимум один Redirect URI.");
-
-            // 3) Local roles
-            var localsRaw = TryParseList(LocalRolesJson);
-            var locals = localsRaw.Select(s => (s ?? "").Trim())
-                                  .Where(s => !string.IsNullOrWhiteSpace(s))
-                                  .Distinct(StringComparer.OrdinalIgnoreCase)
-                                  .ToList();
-            LocalRolesJson = JsonSerializer.Serialize(locals);
-
-            var roleRx = new Regex(@"^[a-z][a-z0-9._:-]{2,63}$");
-            var badLocal = locals.Where(r => !roleRx.IsMatch(r)).ToList();
-            if (badLocal.Any())
-                ModelState.AddModelError(nameof(LocalRolesJson), $"Некорректные локальные роли: {string.Join(", ", badLocal)}");
-            if (locals.Count > 20)
-                ModelState.AddModelError(nameof(LocalRolesJson), "Слишком много локальных ролей (максимум 10).");
-
-            // 4) Service roles: "serviceId: roleName"
-            var svcRaw = NormalizeList(TryParseList(ServiceRolesJson));
-            var restrictedClients = await _exclusions.GetAllAsync(ct);
-            var badSvc = new List<string>();
-            var clientIdRx = new Regex(@"^[a-z0-9][a-z0-9-]{2,60}$");
-            foreach (var s in svcRaw)
-            {
-                var idx = s.IndexOf(':');
-                if (idx <= 0 || idx >= s.Length - 1) { badSvc.Add(s); continue; }
-                var svc = s[..idx].Trim();
-                var role = s[(idx + 1)..].Trim();
-                if (!clientIdRx.IsMatch(svc) || !roleRx.IsMatch(role) || restrictedClients.Contains(svc)) badSvc.Add(s);
-            }
-            if (badSvc.Any())
-                ModelState.AddModelError(nameof(ServiceRolesJson), $"Некорректные сервисные роли: {string.Join(", ", badSvc)}");
-
-            // 5) Ошибки?
-            if (!ModelState.IsValid)
-            {
-                StepToShow = DetermineStepFromErrors(ModelState);
-                return Page();
+                await _repo.AddAsync(username, summary, ct);
             }
 
-            // 6) Сбор спецификации и вызов ClientsService.CreateClientAsync
-            static List<(string ClientId, string Role)> ParseService(string? json)
-            {
-                var res = new List<(string, string)>();
-                var arr = string.IsNullOrWhiteSpace(json)? new List<string>(): (JsonSerializer.Deserialize<List<string>>(json!) ?? new List<string>());
-                foreach (var s in arr)
-                {
-                    var idx = s.IndexOf(':');
-                    if (idx <= 0) continue;
-                    var cid = s[..idx].Trim();
-                    var role = s[(idx + 1)..].Trim();
-                    if (!string.IsNullOrWhiteSpace(cid) && !string.IsNullOrWhiteSpace(role))
-                        res.Add((cid, role));
-                }
-                return res;
-            }
-
-            var spec = new NewClientSpec(
-                Realm: Realm!,
-                ClientId: ClientId!,
-                Description: Description,
-                ClientAuthentication: ClientAuth,
-                StandardFlow: FlowStandard,
-                ServiceAccount: FlowService,
-                RedirectUris: redirects,
-                LocalRoles: locals,
-                ServiceRoles: ParseService(ServiceRolesJson)
-            );
-
-            try
-            {
-                var createdId = await _clients.CreateClientAsync(spec, ct);
-
-                var summary = new ClientSummary(
-                    Name: AppName ?? spec.ClientId,
-                    ClientId: spec.ClientId,
-                    Realm: spec.Realm,
-                    Enabled: true,
-                    FlowStandard: spec.StandardFlow,
-                    FlowService: spec.ServiceAccount);
-                var username = User.Identity?.Name ?? string.Empty;
-                if (!string.IsNullOrEmpty(username))
-                    await _repo.AddAsync(username, summary, ct);
-
-                TempData["FlashOk"] = $"Клиент '{spec.ClientId}' создан (id={createdId}).";
-                return RedirectToPage("/Index");
-            }
-            catch (Exception ex)
-            {
-                ModelState.AddModelError(string.Empty, $"Ошибка создания клиента: {ex.Message}");
-                StepToShow = DetermineStepFromErrors(ModelState);
-                return Page();
-            }
+            TempData["FlashOk"] = $"Клиент '{spec.ClientId}' создан (id={createdId}).";
+            return RedirectToPage("/Index");
+        }
+        catch (Exception ex)
+        {
+            ModelState.AddModelError(string.Empty, $"Ошибка создания клиента: {ex.Message}");
+            StepToShow = DetermineStepFromErrors(ModelState);
+            return Page();
         }
     }
 }

--- a/Pages/Clients/Details.cshtml.cs
+++ b/Pages/Clients/Details.cshtml.cs
@@ -1,187 +1,157 @@
-﻿// Pages/Clients/Details.cshtml.cs
 using Assistant.KeyCloak;
+using Assistant.KeyCloak.Models;
 using Assistant.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using System.Collections.Generic;
-using System;
 using System.Text.Json;
-using System.Linq;
 
-namespace Assistant.Pages.Clients
+namespace Assistant.Pages.Clients;
+
+public class DetailsModel : PageModel
 {
-    public class DetailsModel : PageModel
+    private readonly ClientsService _clients;
+    private readonly UserClientsRepository _repo;
+    private readonly EventsService _events;
+
+    public DetailsModel(ClientsService clients, UserClientsRepository repo, EventsService events)
     {
-        private readonly ClientsService _clients;
-        private readonly UserClientsRepository _repo;
-        private readonly EventsService _events;
+        _clients = clients;
+        _repo = repo;
+        _events = events;
+    }
 
-        public DetailsModel(ClientsService clients, UserClientsRepository repo, EventsService events)
+    [BindProperty(SupportsGet = true)] public string? Realm { get; set; }
+    [BindProperty(SupportsGet = true)] public string? ClientId { get; set; }
+
+    public ClientVm Client { get; set; } = default!;
+    [BindProperty] public string? NewClientId { get; set; }
+    [BindProperty] public string? Description { get; set; }
+    [BindProperty] public bool Enabled { get; set; }
+    [BindProperty] public bool ClientAuth { get; set; }
+    [BindProperty] public bool StandardFlow { get; set; }
+    [BindProperty] public bool ServiceAccount { get; set; }
+    [BindProperty] public string RedirectUrisJson { get; set; } = "[]";
+    [BindProperty] public string LocalRolesJson { get; set; } = "[]";
+    [BindProperty] public string ServiceRolesJson { get; set; } = "[]";
+    public string EventTypesJson { get; set; } = "[]";
+
+    public async Task<IActionResult> OnGetAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(Realm) || string.IsNullOrWhiteSpace(ClientId))
         {
-            _clients = clients;
-            _repo = repo;
-            _events = events;
+            return NotFound();
         }
 
-        // Параметры из query: ?realm=...&clientId=...
-        [BindProperty(SupportsGet = true)] public string? Realm { get; set; }
-        [BindProperty(SupportsGet = true)] public string? ClientId { get; set; }
-
-        // То самое, что используется в cshtml: client?.ClientAuth и т.д.
-        public ClientVm Client { get; set; } = default!;
-        [BindProperty] public string? NewClientId { get; set; }
-        [BindProperty] public string? Description { get; set; }
-        [BindProperty] public bool Enabled { get; set; }
-        [BindProperty] public bool ClientAuth { get; set; }
-        [BindProperty] public bool StandardFlow { get; set; }
-        [BindProperty] public bool ServiceAccount { get; set; }
-        [BindProperty] public string RedirectUrisJson { get; set; } = "[]";
-        [BindProperty] public string LocalRolesJson { get; set; } = "[]";
-        [BindProperty] public string ServiceRolesJson { get; set; } = "[]";
-        public string EventTypesJson { get; set; } = "[]";
-        // public string DefaultScopesJson { get; private set; } = "[]";
-
-        public async Task<IActionResult> OnGetAsync(CancellationToken ct)
+        var details = await _clients.GetClientDetailsAsync(Realm!, ClientId!, ct);
+        if (details == null)
         {
-            if (string.IsNullOrWhiteSpace(Realm) || string.IsNullOrWhiteSpace(ClientId))
-                return NotFound();
-
-            var details = await _clients.GetClientDetailsAsync(Realm!, ClientId!, ct);
-            if (details == null) return NotFound();
-
-            Client = new ClientVm
-            {
-                ClientId = details.ClientId,
-                Realm = Realm!,
-                Enabled = details.Enabled,
-                Description = details.Description,
-                ClientAuth = details.ClientAuth,
-                StandardFlow = details.StandardFlow,
-                ServiceAccount = details.ServiceAccount
-            };
-            NewClientId = details.ClientId;
-            Description = details.Description;
-            Enabled = details.Enabled;
-            ClientAuth = details.ClientAuth;
-            StandardFlow = details.StandardFlow;
-            ServiceAccount = details.ServiceAccount;
-
-            RedirectUrisJson = JsonSerializer.Serialize(details.RedirectUris);
-            LocalRolesJson = JsonSerializer.Serialize(details.LocalRoles);
-            ServiceRolesJson = JsonSerializer.Serialize(details.ServiceRoles.Select(p => $"{p.ClientId}: {p.Role}"));
-            EventTypesJson = JsonSerializer.Serialize(await _events.GetEventTypesAsync(Realm!, ct));
-            // DefaultScopesJson = JsonSerializer.Serialize(details.DefaultScopes);
-
-            return Page();
+            return NotFound();
         }
 
-        public async Task<IActionResult> OnPostSaveAsync(CancellationToken ct)
+        Client = new ClientVm
         {
-            if (string.IsNullOrWhiteSpace(Realm) || string.IsNullOrWhiteSpace(ClientId))
-                return NotFound();
+            ClientId = details.ClientId,
+            Realm = Realm!,
+            Enabled = details.Enabled,
+            Description = details.Description,
+            ClientAuth = details.ClientAuth,
+            StandardFlow = details.StandardFlow,
+            ServiceAccount = details.ServiceAccount
+        };
 
-            string newId = NewClientId?.Trim() ?? ClientId!;
-            var redirects = TryParseList(RedirectUrisJson);
-            var locals = TryParseList(LocalRolesJson);
-            var svc = ParseServiceRoles(ServiceRolesJson);
+        NewClientId = details.ClientId;
+        Description = details.Description;
+        Enabled = details.Enabled;
+        ClientAuth = details.ClientAuth;
+        StandardFlow = details.StandardFlow;
+        ServiceAccount = details.ServiceAccount;
 
-            var spec = new UpdateClientSpec(
-                Realm!,
-                ClientId!,
-                newId,
-                Enabled,
-                Description,
-                ClientAuth,
-                StandardFlow,
-                ServiceAccount,
-                redirects,
-                locals,
-                svc
-            );
+        RedirectUrisJson = JsonSerializer.Serialize(details.RedirectUris);
+        LocalRolesJson = JsonSerializer.Serialize(details.LocalRoles);
+        ServiceRolesJson = JsonSerializer.Serialize(details.ServiceRoles.Select(p => $"{p.ClientId}: {p.Role}"));
+        EventTypesJson = JsonSerializer.Serialize(await _events.GetEventTypesAsync(Realm!, ct));
 
-            try
-            {
-                await _clients.UpdateClientAsync(spec, ct);
-            }
-            catch (Exception ex)
-            {
-                TempData["FlashError"] = $"Не удалось обновить клиента: {ex.Message}";
-                return RedirectToPage(new { realm = Realm, clientId = ClientId });
-            }
+        return Page();
+    }
 
-            TempData["FlashOk"] = "Клиент успешно обновлён.";
-            return RedirectToPage(new { realm = Realm, clientId = newId });
+    public async Task<IActionResult> OnPostSaveAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(Realm) || string.IsNullOrWhiteSpace(ClientId))
+        {
+            return NotFound();
         }
 
-        public async Task<IActionResult> OnPostDeleteAsync(CancellationToken ct)
-        {
-            if (string.IsNullOrWhiteSpace(Realm) || string.IsNullOrWhiteSpace(ClientId))
-                return NotFound();
+        var newId = NewClientId?.Trim() ?? ClientId!;
+        var redirects = ClientFormUtilities.ParseStringList(RedirectUrisJson);
+        var locals = ClientFormUtilities.ParseStringList(LocalRolesJson);
+        var svc = ClientFormUtilities.ParseServiceRolePairs(ServiceRolesJson);
 
-            await _clients.DeleteClientAsync(Realm!, ClientId!, ct);
-            await _repo.RemoveAsync(ClientId!, Realm!, ct);
-            TempData["FlashOk"] = "Client deleted.";
-            return RedirectToPage("/Index");
+        var spec = new UpdateClientSpec(
+            Realm!,
+            ClientId!,
+            newId,
+            Enabled,
+            Description,
+            ClientAuth,
+            StandardFlow,
+            ServiceAccount,
+            redirects,
+            locals,
+            svc);
+
+        try
+        {
+            await _clients.UpdateClientAsync(spec, ct);
+        }
+        catch (Exception ex)
+        {
+            TempData["FlashError"] = $"Не удалось обновить клиента: {ex.Message}";
+            return RedirectToPage(new { realm = Realm, clientId = ClientId });
         }
 
-        public async Task<IActionResult> OnGetEventsAsync(string realm, string clientId, string? type, DateTime? from, DateTime? to, string? user, string? ip, CancellationToken ct)
+        TempData["FlashOk"] = "Клиент успешно обновлён.";
+        return RedirectToPage(new { realm = Realm, clientId = newId });
+    }
+
+    public async Task<IActionResult> OnPostDeleteAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(Realm) || string.IsNullOrWhiteSpace(ClientId))
         {
-            var list = await _events.GetEventsAsync(realm, clientId, type, from, to, user, ip, ct: ct);
-            return new JsonResult(list);
+            return NotFound();
         }
 
-        private static List<string> TryParseList(string? json)
-        {
-            try
-            {
-                return string.IsNullOrWhiteSpace(json)
-                    ? new List<string>()
-                    : (JsonSerializer.Deserialize<List<string>>(json!) ?? new List<string>());
-            }
-            catch { return new List<string>(); }
-        }
+        await _clients.DeleteClientAsync(Realm!, ClientId!, ct);
+        await _repo.RemoveAsync(ClientId!, Realm!, ct);
+        TempData["FlashOk"] = "Client deleted.";
+        return RedirectToPage("/Index");
+    }
 
-        private static List<(string ClientId, string Role)> ParseServiceRoles(string? json)
-        {
-            var list = new List<(string, string)>();
-            foreach (var s in TryParseList(json))
-            {
-                var parts = s.Split(':', 2);
-                if (parts.Length == 2)
-                {
-                    var cid = parts[0].Trim();
-                    var role = parts[1].Trim();
-                    if (!string.IsNullOrWhiteSpace(cid) && !string.IsNullOrWhiteSpace(role))
-                        list.Add((cid, role));
-                }
-            }
-            return list;
-        }
+    public async Task<IActionResult> OnGetEventsAsync(string realm, string clientId, string? type, DateTime? from, DateTime? to, string? user, string? ip, CancellationToken ct)
+    {
+        var list = await _events.GetEventsAsync(realm, clientId, type, from, to, user, ip, ct: ct);
+        return new JsonResult(list);
+    }
 
-        // ===== AJAX handlers для фронта Service Roles =====
-        public async Task<IActionResult> OnGetRoleLookupAsync(string realm, string q, int clientFirst = 0, int clientsToScan = 25, int rolesPerClient = 10, CancellationToken ct = default)
-        {
-            var (hits, next) = await _clients.FindRolesAcrossClientsAsync(realm, q, clientFirst, clientsToScan, rolesPerClient, ct);
-            return new JsonResult(new { hits, nextClientFirst = next });
-        }
+    public async Task<IActionResult> OnGetRoleLookupAsync(string realm, string q, int clientFirst = 0, int clientsToScan = 25, int rolesPerClient = 10, CancellationToken ct = default)
+    {
+        var (hits, next) = await _clients.FindRolesAcrossClientsAsync(realm, q, clientFirst, clientsToScan, rolesPerClient, ct);
+        return new JsonResult(new { hits, nextClientFirst = next });
+    }
 
-        public async Task<IActionResult> OnGetClientsSearchAsync(string realm, string q, int first = 0, int max = 20, CancellationToken ct = default)
-            => new JsonResult(await _clients.SearchClientsAsync(realm, q ?? "", first, max, ct));
+    public async Task<IActionResult> OnGetClientsSearchAsync(string realm, string q, int first = 0, int max = 20, CancellationToken ct = default)
+        => new JsonResult(await _clients.SearchClientsAsync(realm, q ?? string.Empty, first, max, ct));
 
-        public async Task<IActionResult> OnGetClientRolesAsync(string realm, string id, int first = 0, int max = 50, string? q = null, CancellationToken ct = default)
-            => new JsonResult(await _clients.GetClientRolesAsync(realm, id, first, max, q, ct));
+    public async Task<IActionResult> OnGetClientRolesAsync(string realm, string id, int first = 0, int max = 50, string? q = null, CancellationToken ct = default)
+        => new JsonResult(await _clients.GetClientRolesAsync(realm, id, first, max, q, ct));
 
-        public class ClientVm
-        {
-            public string ClientId { get; set; } = default!;
-            public string Realm { get; set; } = default!;
-            public bool Enabled { get; set; }
-            public string? Description { get; set; }
-
-            // НУЖНЫЕ поля для Razor
-            public bool ClientAuth { get; set; }   // конфиденциальный клиент?  = !publicClient
-            public bool StandardFlow { get; set; }   // standardFlowEnabled
-            public bool ServiceAccount { get; set; }   // serviceAccountsEnabled
-        }
+    public class ClientVm
+    {
+        public string ClientId { get; set; } = default!;
+        public string Realm { get; set; } = default!;
+        public bool Enabled { get; set; }
+        public string? Description { get; set; }
+        public bool ClientAuth { get; set; }
+        public bool StandardFlow { get; set; }
+        public bool ServiceAccount { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- extract shared Keycloak admin HTTP helpers and strongly typed client models
- refactor `ClientsService` to use the shared helpers, reduce duplication, and tighten auditing logic
- add reusable form utilities for client pages and streamline create/edit Razor page models
- align `EventsService` and `RealmsService` with the shared HTTP handling helpers

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb533cef94832db4eb26f1a5474e79