### PR TITLE
Improve page transition animation

### DIFF
--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -527,8 +527,14 @@
 /* Page transition animation */
 #app {
     opacity: 0;
-    transform: translateY(10px);
-    transition: opacity 0.3s ease, transform 0.3s ease;
+    transform: translateY(12px);
+    transition: opacity 0.4s cubic-bezier(0.22, 1, 0.36, 1), transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+body.page-transitioning #app {
+    opacity: 0;
+    transform: translateY(12px);
+    pointer-events: none;
 }
 
 body.page-loaded #app {


### PR DESCRIPTION
## Summary
- soften the page transition styling with a smoother easing curve and dedicated transitioning state
- wait for the fade-out animation to finish before swapping the app content to avoid abrupt opacity changes

## Testing
- Not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cbc966525c832dac50d7d9ea74228b