### PR TITLE
Fix service roles search initialization after soft navigation

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -587,7 +587,7 @@
     </script>
 
     <!-- Изолированный модуль Service Roles -->
-    <script>
+    <script data-soft-nav>
         (() => {
           // helpers
           const $  = (s, r=document)=>r.querySelector(s);


### PR DESCRIPTION
## Summary
- ensure the service roles search script participates in soft navigation reloads so its event handlers attach

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7933891c832d93213af92636e92d