### PR TITLE
Align client form input styling

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -88,7 +88,7 @@
                         <div class="prefix-wrap">
                             <span class="prefix-chip" id="cidPrefix">app-bank-</span>
                             <input id="cidInput"
-                                   class="prefix-input"
+                                   class="prefix-input text-sm"
                                    maxlength="25"
                                    placeholder="my-service"
                                    autocomplete="off" autocapitalize="off" spellcheck="false"

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -132,18 +132,19 @@
 .prefix-wrap {
     display: flex;
     align-items: center;
-    border: 1px solid var(--kc-card-border);
-    background: rgba(255,255,255,.05);
+    border: 1px solid var(--kc-border-strong);
+    background: #0a0f18;
     border-radius: .75rem;
     overflow: hidden;
+    transition: border-color .2s ease;
 }
 
 .prefix-chip {
     padding: .5rem .65rem;
-    background: rgba(99,102,241,.15);
+    background: rgba(99,102,241,.2);
     color: var(--kc-ink);
     white-space: nowrap;
-    border-right: 1px solid var(--kc-border);
+    border-right: 1px solid var(--kc-border-strong);
 }
 
 .prefix-input {
@@ -152,6 +153,16 @@
     outline: none;
     padding: .55rem .75rem;
     color: var(--kc-ink);
+    font-size: .875rem;
+    border: none;
+}
+
+.prefix-input::placeholder {
+    color: rgba(226,232,240,.6);
+}
+
+.prefix-wrap:focus-within {
+    border-color: rgba(255,255,255,.25);
 }
 
 /* ===== Chips ===== */


### PR DESCRIPTION
## Summary
- align the client ID input markup with a consistent text size utility
- refresh the prefix input styles so the client ID and description inputs share the same background, border, and focus treatment

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd77de03c0832da1e20957e8ffb4fe