### PR TITLE
Preserve client search results when returning from details

### DIFF
--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -18,7 +18,7 @@
 <!-- Хедер -->
 <div class="kc-header p-5 md:p-6 relative overflow-hidden mb-5">
     <div class="flex items-center">
-        <a asp-page="/Index" class="text-slate-400 text-sm hover:text-slate-200">&larr; Back to Clients</a>
+        <a href="@Model.BackUrl" class="text-slate-400 text-sm hover:text-slate-200">&larr; Back to Clients</a>
         <div class="ml-auto text-slate-400 text-sm">Realm: <span class="text-slate-200">@realm</span></div>
     </div>
     <div class="absolute inset-0 pointer-events-none">
@@ -404,6 +404,7 @@
 
 <!-- Hidden form for saving -->
 <form method="post" id="saveForm" asp-page-handler="Save" asp-route-realm="@realm" asp-route-clientId="@clientId" class="hidden">
+    <input type="hidden" asp-for="ReturnUrl" />
     <input type="hidden" asp-for="NewClientId" id="hidClientId" />
     <input type="hidden" asp-for="Description" id="hidDescription" />
     <input type="hidden" asp-for="Enabled" id="hidEnabled" />
@@ -415,7 +416,9 @@
     <input type="hidden" asp-for="ServiceRolesJson" id="hidServiceRoles" />
 </form>
 
-<form method="post" id="deleteForm" asp-page-handler="Delete" asp-route-realm="@realm" asp-route-clientId="@clientId" class="hidden"></form>
+<form method="post" id="deleteForm" asp-page-handler="Delete" asp-route-realm="@realm" asp-route-clientId="@clientId" class="hidden">
+    <input type="hidden" asp-for="ReturnUrl" />
+</form>
 
 @section Toasts {
     @if (TempData["FlashOk"] is string ok)

--- a/Pages/Shared/_ClientsList.cshtml
+++ b/Pages/Shared/_ClientsList.cshtml
@@ -2,6 +2,9 @@
 
 @{
     var currentPage = (ViewContext.RouteData.Values["page"] as string) ?? string.Empty;
+    var returnUrl = string.IsNullOrEmpty(currentPage)
+        ? null
+        : Url.Page(currentPage, new { q = Model.Q, pageNumber = Model.PageNumber });
 }
 
 @if (!Model.Clients.Any() && Model.ShowEmptyMessage)
@@ -21,6 +24,7 @@ else if (Model.Clients.Any())
             var envList = Model.Envs(c.Realm).ToList();
 
             <a asp-page="/Clients/Details" asp-route-realm="@c.Realm" asp-route-clientId="@c.ClientId"
+               asp-route-returnUrl="@returnUrl"
                class="block group client-card"
                 data-search="@($"{c.ClientId} {c.Realm} {Model.DescFor(c.ClientId)}")">
                 <div class="kc-card kc-card--hover p-5 h-44 overflow-hidden transition relative">


### PR DESCRIPTION
## Summary
- pass the current list page as a returnUrl when opening client details
- bind and sanitize the returnUrl in the details page model to build a safe back link
- keep the sanitized returnUrl in save/delete flows so admins can go back to the same search results

## Testing
- `dotnet build` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9efee840832dacddae63da5f4cab