### PR TITLE
Add admin UI for assigning client access to users

### DIFF
--- a/KeyCloak/UsersService.cs
+++ b/KeyCloak/UsersService.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Assistant.KeyCloak;
+
+public sealed record UserSearchResult(string Username, string? FirstName, string? LastName, string? Email)
+{
+    public string DisplayName
+    {
+        get
+        {
+            var segments = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(LastName))
+            {
+                segments.Add(LastName!.Trim());
+            }
+
+            if (!string.IsNullOrWhiteSpace(FirstName))
+            {
+                segments.Add(FirstName!.Trim());
+            }
+
+            var name = string.Join(" ", segments);
+
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(Email))
+            {
+                return $"{Username} — {name} ({Email!.Trim()})";
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                return $"{Username} — {name}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(Email))
+            {
+                return $"{Username} — {Email!.Trim()}";
+            }
+
+            return Username;
+        }
+    }
+}
+
+public sealed class UsersService
+{
+    private readonly IHttpClientFactory _factory;
+    private readonly AdminApiOptions _opt;
+    private readonly string _primaryRealm;
+
+    private sealed class UserRepresentation
+    {
+        public string? Id { get; set; }
+        public string? Username { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public UsersService(
+        IHttpClientFactory factory,
+        IOptions<AdminApiOptions> opt,
+        IConfiguration configuration)
+    {
+        _factory = factory;
+        _opt = opt.Value;
+        _primaryRealm = (configuration["Keycloak:PrimaryRealm"] ?? configuration["Keycloak:Realm"])
+            ?? throw new InvalidOperationException("Keycloak primary realm is not configured.");
+    }
+
+    public string PrimaryRealm => _primaryRealm;
+
+    private HttpClient CreateAdminClient() => _factory.CreateClient("kc-admin");
+
+    private string BaseUrl => _opt.BaseUrl.TrimEnd('/');
+
+    private static string UR(string value) => Uri.EscapeDataString(value);
+
+    public async Task<List<UserSearchResult>> SearchUsersAsync(
+        string query,
+        int first = 0,
+        int max = 20,
+        CancellationToken ct = default)
+    {
+        query = (query ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(query))
+        {
+            return new List<UserSearchResult>();
+        }
+
+        first = Math.Max(0, first);
+        max = Math.Clamp(max <= 0 ? 20 : max, 1, 200);
+
+        var http = CreateAdminClient();
+
+        var urlNew = $"{BaseUrl}/admin/realms/{UR(_primaryRealm)}/users?search={UR(query)}&first={first}&max={max}";
+        var urlLegacy = $"{BaseUrl}/auth/admin/realms/{UR(_primaryRealm)}/users?search={UR(query)}&first={first}&max={max}";
+
+        using var resp = await http.GetWithLegacyFallbackAsync(urlNew, urlLegacy, ct);
+        resp.EnsureAdminSuccess();
+
+        var raw = await resp.Content.ReadFromJsonAsync<List<UserRepresentation>>(JsonOpts, ct)
+                  ?? new List<UserRepresentation>();
+
+        return raw
+            .Where(u => !string.IsNullOrWhiteSpace(u.Username))
+            .Select(MapUser)
+            .GroupBy(u => u.Username, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .OrderBy(u => u.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static UserSearchResult MapUser(UserRepresentation user)
+    {
+        var username = user.Username!.Trim();
+        return new UserSearchResult(
+            username,
+            Normalize(user.FirstName),
+            Normalize(user.LastName),
+            Normalize(user.Email));
+    }
+
+    private static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -1,0 +1,259 @@
+@page
+@model Assistant.Pages.Admin.UserClientsModel
+@{
+    ViewData["Title"] = "Назначение доступа к клиентам";
+}
+
+<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-5">
+    <div class="absolute inset-0 pointer-events-none">
+        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
+             style="background: radial-gradient(60% 60% at 50% 50%, rgba(14,165,233,.55), rgba(59,130,246,.35))"></div>
+        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
+             style="background: radial-gradient(60% 60% at 50% 50%, rgba(45,212,191,.6), rgba(99,102,241,.35))"></div>
+    </div>
+
+    <div class="relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+            <h3 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(59,130,246,0.25)]">
+                Назначение доступа к клиентам
+            </h3>
+            <p class="text-slate-200/80 mt-2 text-sm max-w-2xl">
+                Выберите клиента Keycloak и пользователя домена, чтобы предоставить доступ к карточке клиента в Assistant.
+            </p>
+        </div>
+    </div>
+</div>
+
+<div class="grid gap-6 lg:grid-cols-2">
+    <section class="kc-card p-5">
+        <div class="flex items-center justify-between mb-4">
+            <h4 class="text-lg font-semibold text-slate-200">Поиск клиента</h4>
+            @if (!string.IsNullOrWhiteSpace(Model.SelectedClientId))
+            {
+                <span class="text-xs text-slate-400">Выбрано: @Model.SelectedClientId (@Model.SelectedClientRealm)</span>
+            }
+        </div>
+
+        <form method="get" class="flex flex-col gap-3">
+            <div class="kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="11" cy="11" r="8" />
+                    <path d="m21 21-4.3-4.3" />
+                </svg>
+                <input name="clientQuery" value="@Model.ClientQuery" placeholder="Введите clientId"
+                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
+            </div>
+            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
+            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+            <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
+            <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
+            <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
+            <button type="submit" class="btn-subtle self-start">Найти клиента</button>
+        </form>
+
+        <div class="mt-4 space-y-3">
+            @if (Model.ClientResults.Any())
+            {
+                foreach (var client in Model.ClientResults)
+                {
+                    <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
+                        <div>
+                            <div class="text-slate-100 font-medium">@client.ClientId</div>
+                            <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @client.Realm</div>
+                        </div>
+                        <form method="get" class="flex items-center gap-2">
+                            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                            <input type="hidden" name="selectedClientId" value="@client.ClientId" />
+                            <input type="hidden" name="selectedClientRealm" value="@client.Realm" />
+                            <input type="hidden" name="selectedClientName" value="@client.Name" />
+                            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
+                            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                            <button type="submit" class="btn-subtle whitespace-nowrap">Выбрать</button>
+                        </form>
+                    </div>
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(Model.ClientQuery))
+            {
+                <div class="text-sm text-slate-400">Клиенты не найдены.</div>
+            }
+            else
+            {
+                <div class="text-sm text-slate-400">Введите идентификатор клиента, чтобы увидеть результаты.</div>
+            }
+        </div>
+    </section>
+
+    <section class="kc-card p-5">
+        <div class="flex items-center justify-between mb-4">
+            <h4 class="text-lg font-semibold text-slate-200">Поиск пользователя</h4>
+            <span class="text-xs text-slate-400">Realm: @Model.PrimaryRealm</span>
+        </div>
+
+        <form method="get" class="flex flex-col gap-3">
+            <div class="kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="11" cy="11" r="8" />
+                    <path d="m21 21-4.3-4.3" />
+                </svg>
+                <input name="userQuery" value="@Model.UserQuery" placeholder="username, email или ФИО"
+                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
+            </div>
+            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+            <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
+            <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
+            <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
+            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
+            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+            <button type="submit" class="btn-subtle self-start">Найти пользователя</button>
+        </form>
+
+        <div class="mt-4 space-y-3">
+            @if (Model.UserResults.Any())
+            {
+                foreach (var user in Model.UserResults)
+                {
+                    <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
+                        <div>
+                            <div class="text-slate-100 font-medium">@user.Username</div>
+                            <div class="text-xs text-slate-400">@user.DisplayName</div>
+                        </div>
+                        <form method="get" class="flex items-center gap-2">
+                            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                            <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
+                            <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
+                            <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
+                            <input type="hidden" name="selectedUsername" value="@user.Username" />
+                            <input type="hidden" name="selectedUserDisplay" value="@user.DisplayName" />
+                            <button type="submit" class="btn-subtle whitespace-nowrap">Выбрать</button>
+                        </form>
+                    </div>
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(Model.UserQuery))
+            {
+                <div class="text-sm text-slate-400">Пользователи не найдены.</div>
+            }
+            else
+            {
+                <div class="text-sm text-slate-400">Введите имя пользователя или email для поиска.</div>
+            }
+        </div>
+    </section>
+</div>
+
+@if (Model.HasClientSelection || Model.HasUserSelection)
+{
+    <div class="grid gap-6 mt-6 lg:grid-cols-2">
+        @if (Model.HasClientSelection)
+        {
+            <div class="kc-card p-5">
+                <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный клиент</h4>
+                <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
+                    <div class="text-slate-100 font-medium text-lg">@Model.SelectedClientId</div>
+                    <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @Model.SelectedClientRealm</div>
+                </div>
+            </div>
+        }
+
+        @if (Model.HasUserSelection)
+        {
+            <div class="kc-card p-5">
+                <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный пользователь</h4>
+                <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
+                    <div class="text-slate-100 font-medium text-lg">@Model.SelectedUsername</div>
+                    <div class="text-xs text-slate-400">@Model.SelectedUserDisplay</div>
+                </div>
+            </div>
+        }
+    </div>
+}
+
+@if (Model.CanGrant)
+{
+    <div class="kc-card p-5 mt-6">
+        <h4 class="text-lg font-semibold text-slate-200">Предоставить доступ</h4>
+        <p class="text-sm text-slate-400 mt-2">
+            Клиент <span class="text-slate-200 font-medium">@Model.SelectedClientId</span> из realm
+            <span class="text-slate-200 font-medium">@Model.SelectedClientRealm</span> будет доступен пользователю
+            <span class="text-slate-200 font-medium">@Model.SelectedUsername</span>.
+        </p>
+
+        <form method="post" asp-page-handler="Grant" class="mt-4 flex flex-wrap items-center gap-3">
+            <input type="hidden" name="realm" value="@Model.SelectedClientRealm" />
+            <input type="hidden" name="clientId" value="@Model.SelectedClientId" />
+            <input type="hidden" name="clientName" value="@Model.SelectedClientName" />
+            <input type="hidden" name="username" value="@Model.SelectedUsername" />
+            <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
+            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+            <button type="submit" class="btn-primary">Назначить доступ</button>
+        </form>
+    </div>
+}
+
+@if (Model.HasUserSelection)
+{
+    <div class="kc-card p-5 mt-6">
+        <div class="flex items-center justify-between mb-4">
+            <h4 class="text-lg font-semibold text-slate-200">Клиенты пользователя @Model.SelectedUsername</h4>
+            <span class="text-xs text-slate-400">Всего: @Model.Assignments.Count</span>
+        </div>
+
+        @if (Model.Assignments.Any())
+        {
+            <div class="space-y-3">
+                @foreach (var client in Model.Assignments.OrderBy(c => c.Realm).ThenBy(c => c.ClientId))
+                {
+                    <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
+                        <div>
+                            <div class="text-slate-100 font-medium">@client.ClientId</div>
+                            <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @client.Realm</div>
+                        </div>
+                        <form method="post" asp-page-handler="Revoke" class="flex items-center gap-2">
+                            <input type="hidden" name="realm" value="@client.Realm" />
+                            <input type="hidden" name="clientId" value="@client.ClientId" />
+                            <input type="hidden" name="username" value="@Model.SelectedUsername" />
+                            <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
+                            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                            <button type="submit" class="btn-danger whitespace-nowrap">Удалить</button>
+                        </form>
+                    </div>
+                }
+            </div>
+        }
+        else
+        {
+            <div class="text-sm text-slate-400">Для выбранного пользователя пока нет назначенных клиентов.</div>
+        }
+    </div>
+}
+
+@section Toasts {
+    @if (TempData["FlashOk"] is string ok)
+    {
+        <div class="kc-toast kc-toast-success" id="flashToastOk" role="alert">
+            <div class="kc-toast-icon">✓</div>
+            <div class="kc-toast-body">
+                <div class="kc-toast-title">@ok</div>
+            </div>
+            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
+        </div>
+        <script data-soft-nav>setTimeout(() => document.getElementById('flashToastOk')?.remove(), 10000);</script>
+    }
+    @if (TempData["FlashError"] is string err)
+    {
+        <div class="kc-toast kc-toast-error" id="flashToastError" role="alert">
+            <div class="kc-toast-icon">!</div>
+            <div class="kc-toast-body">
+                <div class="kc-toast-title">@err</div>
+            </div>
+            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
+        </div>
+        <script data-soft-nav>setTimeout(() => document.getElementById('flashToastError')?.remove(), 10000);</script>
+    }
+}

--- a/Pages/Admin/UserClients.cshtml.cs
+++ b/Pages/Admin/UserClients.cshtml.cs
@@ -1,0 +1,223 @@
+using Assistant.Interfaces;
+using Assistant.KeyCloak;
+using Assistant.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Assistant.Pages.Admin;
+
+[Authorize(Roles = "assistant-admin")]
+public sealed class UserClientsModel : PageModel
+{
+    private readonly RealmsService _realms;
+    private readonly ClientsService _clients;
+    private readonly UsersService _users;
+    private readonly UserClientsRepository _repo;
+
+    public UserClientsModel(
+        RealmsService realms,
+        ClientsService clients,
+        UsersService users,
+        UserClientsRepository repo)
+    {
+        _realms = realms;
+        _clients = clients;
+        _users = users;
+        _repo = repo;
+    }
+
+    [BindProperty(SupportsGet = true)] public string? ClientQuery { get; set; }
+    [BindProperty(SupportsGet = true)] public string? UserQuery { get; set; }
+    [BindProperty(SupportsGet = true)] public string? SelectedClientId { get; set; }
+    [BindProperty(SupportsGet = true)] public string? SelectedClientRealm { get; set; }
+    [BindProperty(SupportsGet = true)] public string? SelectedClientName { get; set; }
+    [BindProperty(SupportsGet = true)] public string? SelectedUsername { get; set; }
+    [BindProperty(SupportsGet = true)] public string? SelectedUserDisplay { get; set; }
+
+    public List<ClientSummary> ClientResults { get; private set; } = [];
+    public List<UserSearchResult> UserResults { get; private set; } = [];
+    public List<ClientSummary> Assignments { get; private set; } = [];
+
+    public string PrimaryRealm => _users.PrimaryRealm;
+
+    public bool HasClientSelection =>
+        !string.IsNullOrWhiteSpace(SelectedClientId) && !string.IsNullOrWhiteSpace(SelectedClientRealm);
+
+    public bool HasUserSelection => !string.IsNullOrWhiteSpace(SelectedUsername);
+
+    public bool CanGrant => HasClientSelection && HasUserSelection;
+
+    public async Task OnGetAsync(CancellationToken ct)
+    {
+        await LoadClientResultsAsync(ct);
+        await LoadUserResultsAsync(ct);
+        await LoadAssignmentsAsync(ct);
+        NormalizeSelection();
+    }
+
+    private void NormalizeSelection()
+    {
+        if (HasClientSelection && string.IsNullOrWhiteSpace(SelectedClientName))
+        {
+            SelectedClientName = SelectedClientId;
+        }
+
+        if (HasUserSelection && string.IsNullOrWhiteSpace(SelectedUserDisplay))
+        {
+            SelectedUserDisplay = SelectedUsername;
+        }
+    }
+
+    private async Task LoadClientResultsAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(ClientQuery))
+        {
+            ClientResults = [];
+            return;
+        }
+
+        var query = ClientQuery!.Trim();
+        if (query.Length == 0)
+        {
+            ClientResults = [];
+            return;
+        }
+
+        var realms = await _realms.GetRealmsAsync(ct);
+        var list = new List<ClientSummary>();
+
+        foreach (var realm in realms)
+        {
+            if (string.IsNullOrWhiteSpace(realm.Realm))
+            {
+                continue;
+            }
+
+            var hits = await _clients.SearchClientsAsync(realm.Realm!, query, 0, 5, ct);
+            foreach (var hit in hits)
+            {
+                list.Add(new ClientSummary(
+                    Name: hit.ClientId,
+                    ClientId: hit.ClientId,
+                    Realm: realm.Realm!,
+                    Enabled: true,
+                    FlowStandard: false,
+                    FlowService: false));
+            }
+        }
+
+        ClientResults = list
+            .OrderBy(c => c.Realm, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(c => c.ClientId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private async Task LoadUserResultsAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(UserQuery))
+        {
+            UserResults = [];
+            return;
+        }
+
+        var query = UserQuery!.Trim();
+        if (query.Length == 0)
+        {
+            UserResults = [];
+            return;
+        }
+
+        UserResults = await _users.SearchUsersAsync(query, 0, 20, ct);
+    }
+
+    private async Task LoadAssignmentsAsync(CancellationToken ct)
+    {
+        if (!HasUserSelection)
+        {
+            Assignments = [];
+            return;
+        }
+
+        Assignments = await _repo.GetForUserAsync(SelectedUsername!, isAdmin: false, ct);
+    }
+
+    public async Task<IActionResult> OnPostGrantAsync(
+        string realm,
+        string clientId,
+        string? clientName,
+        string username,
+        string? userDisplay,
+        string? clientQuery,
+        string? userQuery,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(realm) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(username))
+        {
+            TempData["FlashError"] = "Выберите клиента и пользователя, прежде чем назначать доступ.";
+            return RedirectToPage(new
+            {
+                clientQuery,
+                userQuery,
+                selectedUsername = username,
+                selectedUserDisplay = userDisplay,
+                selectedClientId = clientId,
+                selectedClientRealm = realm,
+                selectedClientName = clientName
+            });
+        }
+
+        var summary = new ClientSummary(
+            Name: string.IsNullOrWhiteSpace(clientName) ? clientId : clientName!,
+            ClientId: clientId,
+            Realm: realm,
+            Enabled: true,
+            FlowStandard: false,
+            FlowService: false);
+
+        await _repo.AddAsync(username, summary, ct);
+
+        TempData["FlashOk"] = $"Клиент '{clientId}' ({realm}) назначен пользователю {username}.";
+
+        return RedirectToPage(new
+        {
+            clientQuery,
+            userQuery,
+            selectedUsername = username,
+            selectedUserDisplay = string.IsNullOrWhiteSpace(userDisplay) ? username : userDisplay,
+            selectedClientId = clientId,
+            selectedClientRealm = realm,
+            selectedClientName = summary.Name
+        });
+    }
+
+    public async Task<IActionResult> OnPostRevokeAsync(
+        string realm,
+        string clientId,
+        string username,
+        string? userDisplay,
+        string? clientQuery,
+        string? userQuery,
+        CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(realm)
+            && !string.IsNullOrWhiteSpace(clientId)
+            && !string.IsNullOrWhiteSpace(username))
+        {
+            await _repo.RemoveForUserAsync(username, clientId, realm, ct);
+            TempData["FlashOk"] = $"Доступ к клиенту '{clientId}' ({realm}) для пользователя {username} удалён.";
+        }
+        else
+        {
+            TempData["FlashError"] = "Не удалось определить запись для удаления.";
+        }
+
+        return RedirectToPage(new
+        {
+            clientQuery,
+            userQuery,
+            selectedUsername = username,
+            selectedUserDisplay = string.IsNullOrWhiteSpace(userDisplay) ? username : userDisplay
+        });
+    }
+}

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -32,11 +32,11 @@
     @{
         var currentPage = (ViewContext.RouteData.Values["page"] as string) ?? string.Empty;
         var isAdmin = User.IsInRole("assistant-admin");
-        var searchActive = string.Equals(currentPage, "/Clients/Search", System.StringComparison.OrdinalIgnoreCase);
         var linkBase = "flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition";
-        var linkClass = searchActive
-            ? $"{linkBase} bg-white/10 text-white shadow-[0_0_0_1px_rgba(255,255,255,0.08)]"
-            : $"{linkBase} text-slate-300 hover:bg-white/5";
+        string LinkClass(string target)
+            => string.Equals(currentPage, target, System.StringComparison.OrdinalIgnoreCase)
+                ? $"{linkBase} bg-white/10 text-white shadow-[0_0_0_1px_rgba(255,255,255,0.08)]"
+                : $"{linkBase} text-slate-300 hover:bg-white/5";
     }
     <div class="container mx-auto px-4 md:px-6 py-6" data-soft-root>
         <div class="flex flex-col md:flex-row gap-6">
@@ -46,12 +46,19 @@
                     <div class="kc-card p-4 mb-4 md:mb-0 md:sticky md:top-6">
                         <div class="text-xs uppercase tracking-wide text-slate-400 mb-3">Администрирование</div>
                         <nav class="flex flex-col gap-1">
-                            <a asp-page="/Clients/Search" class="@linkClass">
+                            <a asp-page="/Clients/Search" class='@LinkClass("/Clients/Search")'>
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                     <circle cx="11" cy="11" r="8" />
                                     <path d="m21 21-4.3-4.3" />
                                 </svg>
                                 <span>Поиск клиентов</span>
+                            </a>
+                            <a asp-page="/Admin/UserClients" class='@LinkClass("/Admin/UserClients")'>
+                                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M16 7a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" />
+                                    <path d="M5.5 21a6.5 6.5 0 0 1 13 0" />
+                                </svg>
+                                <span>Доступ пользователей</span>
                             </a>
                         </nav>
                     </div>

--- a/Program.cs
+++ b/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddHttpClient("kc-admin", (sp, c) =>
 
 builder.Services.AddScoped<Assistant.KeyCloak.RealmsService>();
 builder.Services.AddScoped<Assistant.KeyCloak.ClientsService>();
+builder.Services.AddScoped<Assistant.KeyCloak.UsersService>();
 builder.Services.AddScoped<Assistant.KeyCloak.EventsService>();
 builder.Services.AddSingleton<UserClientsRepository>();
 builder.Services.AddSingleton<ServiceRoleExclusionsRepository>();

--- a/Services/UserClientsRepository.cs
+++ b/Services/UserClientsRepository.cs
@@ -38,6 +38,12 @@ public class UserClientsRepository
         await using (var cmd = new NpgsqlCommand(sql, conn))
             await cmd.ExecuteNonQueryAsync(ct);
 
+        const string indexSql =
+            "CREATE UNIQUE INDEX IF NOT EXISTS ix_user_clients_identity ON user_clients(username, client_id, realm);";
+
+        await using (var idx = new NpgsqlCommand(indexSql, conn))
+            await idx.ExecuteNonQueryAsync(ct);
+
         _initialized = true;
     }
 
@@ -50,7 +56,12 @@ public class UserClientsRepository
 
         var cmd = new NpgsqlCommand(@"insert into user_clients
                 (username, name, client_id, realm, enabled, flow_standard, flow_service)
-                values (@u, @n, @cid, @r, @en, @std, @svc);", conn);
+                values (@u, @n, @cid, @r, @en, @std, @svc)
+                on conflict (username, client_id, realm) do update set
+                    name = excluded.name,
+                    enabled = excluded.enabled,
+                    flow_standard = excluded.flow_standard,
+                    flow_service = excluded.flow_service;", conn);
 
         cmd.Parameters.AddWithValue("u", username);
         cmd.Parameters.AddWithValue("n", client.Name);
@@ -71,6 +82,23 @@ public class UserClientsRepository
         await conn.OpenAsync(ct);
 
         var cmd = new NpgsqlCommand("delete from user_clients where client_id=@cid and realm=@r", conn);
+        cmd.Parameters.AddWithValue("cid", clientId);
+        cmd.Parameters.AddWithValue("r", realm);
+
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    public async Task RemoveForUserAsync(string username, string clientId, string realm, CancellationToken ct = default)
+    {
+        await EnsureCreatedAsync(ct);
+
+        await using var conn = new NpgsqlConnection(_connString);
+        await conn.OpenAsync(ct);
+
+        var cmd = new NpgsqlCommand(
+            "delete from user_clients where username=@u and client_id=@cid and realm=@r",
+            conn);
+        cmd.Parameters.AddWithValue("u", username);
         cmd.Parameters.AddWithValue("cid", clientId);
         cmd.Parameters.AddWithValue("r", realm);
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -9,6 +9,7 @@
   "Keycloak": {
     "BaseUrl": "http://localhost:8080/", // БАЗОВЫЙ URL Keycloak (без /realms)
     "Realm": "internal-bank-idm",
+    "PrimaryRealm": "internal-bank-idm", // главный realm для поиска пользователей
     "ClientId": "app-assistant-auth",
     "ClientSecret": "0erw5KJrtSLMQAMaLihtIc0XdgdRIk97"
   },


### PR DESCRIPTION
## Summary
- add Keycloak primary realm configuration and a UsersService for searching realm users
- extend the user-clients repository with uniqueness safeguards and per-user removal helpers
- create an admin page for assigning clients to users and expose it via the navigation menu

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cda6135cc0832dacc437a22d0907db