### PR TITLE
Add button loading indicators and paginate admin user clients

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -43,6 +43,8 @@
                 <input name="clientQuery" value="@Model.ClientQuery" placeholder="Введите clientId"
                        class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
             </div>
+            <input type="hidden" name="clientPage" value="1" />
+            <input type="hidden" name="userPage" value="@Model.UserPage" />
             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
             <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
             <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
@@ -55,7 +57,7 @@
         <div class="mt-4 space-y-3">
             @if (Model.ClientResults.Any())
             {
-                foreach (var client in Model.ClientResults)
+                foreach (var client in Model.ClientPageResults)
                 {
                     <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
                         <div>
@@ -65,6 +67,8 @@
                         <form method="get" class="flex items-center gap-2">
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                            <input type="hidden" name="userPage" value="@Model.UserPage" />
                             <input type="hidden" name="selectedClientId" value="@client.ClientId" />
                             <input type="hidden" name="selectedClientRealm" value="@client.Realm" />
                             <input type="hidden" name="selectedClientName" value="@client.Name" />
@@ -72,6 +76,30 @@
                             <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
                             <button type="submit" class="btn-subtle whitespace-nowrap">Выбрать</button>
                         </form>
+                    </div>
+                }
+
+                if (Model.ClientTotalPages > 1)
+                {
+                    <div class="flex flex-wrap items-center gap-2 pt-3 border-t border-white/5">
+                        @for (var pageNumber = 1; pageNumber <= Model.ClientTotalPages; pageNumber++)
+                        {
+                            var isActive = pageNumber == Model.ClientPage;
+                            <form method="get" class="inline-flex">
+                                <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                                <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                                <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
+                                <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
+                                <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
+                                <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
+                                <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                                <input type="hidden" name="clientPage" value="@pageNumber" />
+                                <input type="hidden" name="userPage" value="@Model.UserPage" />
+                                <button type="submit"
+                                        class="btn-subtle text-xs @(isActive ? "btn-subtle-active" : string.Empty)"
+                                        aria-current="@(isActive ? "page" : null)">@pageNumber</button>
+                            </form>
+                        }
                     </div>
                 }
             }
@@ -101,6 +129,8 @@
                 <input name="userQuery" value="@Model.UserQuery" placeholder="username, email или ФИО"
                        class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
             </div>
+            <input type="hidden" name="userPage" value="1" />
+            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
             <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
             <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
@@ -113,7 +143,7 @@
         <div class="mt-4 space-y-3">
             @if (Model.UserResults.Any())
             {
-                foreach (var user in Model.UserResults)
+                foreach (var user in Model.UserPageResults)
                 {
                     <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
                         <div>
@@ -123,6 +153,8 @@
                         <form method="get" class="flex items-center gap-2">
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                            <input type="hidden" name="userPage" value="@Model.UserPage" />
                             <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
                             <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
                             <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
@@ -130,6 +162,30 @@
                             <input type="hidden" name="selectedUserDisplay" value="@user.DisplayName" />
                             <button type="submit" class="btn-subtle whitespace-nowrap">Выбрать</button>
                         </form>
+                    </div>
+                }
+
+                if (Model.UserTotalPages > 1)
+                {
+                    <div class="flex flex-wrap items-center gap-2 pt-3 border-t border-white/5">
+                        @for (var pageNumber = 1; pageNumber <= Model.UserTotalPages; pageNumber++)
+                        {
+                            var isActive = pageNumber == Model.UserPage;
+                            <form method="get" class="inline-flex">
+                                <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                                <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                                <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
+                                <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
+                                <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
+                                <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
+                                <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                                <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                                <input type="hidden" name="userPage" value="@pageNumber" />
+                                <button type="submit"
+                                        class="btn-subtle text-xs @(isActive ? "btn-subtle-active" : string.Empty)"
+                                        aria-current="@(isActive ? "page" : null)">@pageNumber</button>
+                            </form>
+                        }
                     </div>
                 }
             }
@@ -150,7 +206,7 @@
     <div class="grid gap-6 mt-6 lg:grid-cols-2">
         @if (Model.HasClientSelection)
         {
-            <div class="kc-card p-5">
+            <div class="kc-card p-5 soft-fade-panel">
                 <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный клиент</h4>
                 <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
                     <div class="text-slate-100 font-medium text-lg">@Model.SelectedClientId</div>
@@ -161,7 +217,7 @@
 
         @if (Model.HasUserSelection)
         {
-            <div class="kc-card p-5">
+            <div class="kc-card p-5 soft-fade-panel">
                 <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный пользователь</h4>
                 <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
                     <div class="text-slate-100 font-medium text-lg">@Model.SelectedUsername</div>
@@ -174,7 +230,7 @@
 
 @if (Model.CanGrant)
 {
-    <div class="kc-card p-5 mt-6">
+    <div class="kc-card p-5 mt-6 soft-fade-panel">
         <h4 class="text-lg font-semibold text-slate-200">Предоставить доступ</h4>
         <p class="text-sm text-slate-400 mt-2">
             Клиент <span class="text-slate-200 font-medium">@Model.SelectedClientId</span> из realm
@@ -190,6 +246,8 @@
             <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+            <input type="hidden" name="userPage" value="@Model.UserPage" />
             <button type="submit" class="btn-primary">Назначить доступ</button>
         </form>
     </div>
@@ -197,7 +255,7 @@
 
 @if (Model.HasUserSelection)
 {
-    <div class="kc-card p-5 mt-6">
+    <div class="kc-card p-5 mt-6 soft-fade-panel">
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Клиенты пользователя @Model.SelectedUsername</h4>
             <span class="text-xs text-slate-400">Всего: @Model.Assignments.Count</span>
@@ -220,6 +278,8 @@
                             <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                            <input type="hidden" name="userPage" value="@Model.UserPage" />
                             <button type="submit" class="btn-danger whitespace-nowrap">Удалить</button>
                         </form>
                     </div>

--- a/Pages/Admin/UserClients.cshtml.cs
+++ b/Pages/Admin/UserClients.cshtml.cs
@@ -34,10 +34,18 @@ public sealed class UserClientsModel : PageModel
     [BindProperty(SupportsGet = true)] public string? SelectedClientName { get; set; }
     [BindProperty(SupportsGet = true)] public string? SelectedUsername { get; set; }
     [BindProperty(SupportsGet = true)] public string? SelectedUserDisplay { get; set; }
+    [BindProperty(SupportsGet = true)] public int ClientPage { get; set; } = 1;
+    [BindProperty(SupportsGet = true)] public int UserPage { get; set; } = 1;
+
+    private const int PageSize = 5;
 
     public List<ClientSummary> ClientResults { get; private set; } = [];
     public List<UserSearchResult> UserResults { get; private set; } = [];
     public List<ClientSummary> Assignments { get; private set; } = [];
+    public IReadOnlyList<ClientSummary> ClientPageResults { get; private set; } = Array.Empty<ClientSummary>();
+    public IReadOnlyList<UserSearchResult> UserPageResults { get; private set; } = Array.Empty<UserSearchResult>();
+    public int ClientTotalPages { get; private set; }
+    public int UserTotalPages { get; private set; }
 
     public string PrimaryRealm => _users.PrimaryRealm;
 
@@ -74,6 +82,9 @@ public sealed class UserClientsModel : PageModel
         if (string.IsNullOrWhiteSpace(ClientQuery))
         {
             ClientResults = [];
+            ClientPageResults = Array.Empty<ClientSummary>();
+            ClientTotalPages = 0;
+            ClientPage = 1;
             return;
         }
 
@@ -81,6 +92,9 @@ public sealed class UserClientsModel : PageModel
         if (query.Length == 0)
         {
             ClientResults = [];
+            ClientPageResults = Array.Empty<ClientSummary>();
+            ClientTotalPages = 0;
+            ClientPage = 1;
             return;
         }
 
@@ -111,6 +125,8 @@ public sealed class UserClientsModel : PageModel
             .OrderBy(c => c.Realm, StringComparer.OrdinalIgnoreCase)
             .ThenBy(c => c.ClientId, StringComparer.OrdinalIgnoreCase)
             .ToList();
+
+        ApplyClientPagination();
     }
 
     private async Task LoadUserResultsAsync(CancellationToken ct)
@@ -118,6 +134,9 @@ public sealed class UserClientsModel : PageModel
         if (string.IsNullOrWhiteSpace(UserQuery))
         {
             UserResults = [];
+            UserPageResults = Array.Empty<UserSearchResult>();
+            UserTotalPages = 0;
+            UserPage = 1;
             return;
         }
 
@@ -125,10 +144,14 @@ public sealed class UserClientsModel : PageModel
         if (query.Length == 0)
         {
             UserResults = [];
+            UserPageResults = Array.Empty<UserSearchResult>();
+            UserTotalPages = 0;
+            UserPage = 1;
             return;
         }
 
         UserResults = await _users.SearchUsersAsync(query, 0, 20, ct);
+        ApplyUserPagination();
     }
 
     private async Task LoadAssignmentsAsync(CancellationToken ct)
@@ -150,6 +173,8 @@ public sealed class UserClientsModel : PageModel
         string? userDisplay,
         string? clientQuery,
         string? userQuery,
+        int clientPage,
+        int userPage,
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(realm) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(username))
@@ -183,6 +208,8 @@ public sealed class UserClientsModel : PageModel
         {
             clientQuery,
             userQuery,
+            clientPage,
+            userPage,
             selectedUsername = username,
             selectedUserDisplay = string.IsNullOrWhiteSpace(userDisplay) ? username : userDisplay,
             selectedClientId = clientId,
@@ -198,6 +225,8 @@ public sealed class UserClientsModel : PageModel
         string? userDisplay,
         string? clientQuery,
         string? userQuery,
+        int clientPage,
+        int userPage,
         CancellationToken ct)
     {
         if (!string.IsNullOrWhiteSpace(realm)
@@ -216,8 +245,58 @@ public sealed class UserClientsModel : PageModel
         {
             clientQuery,
             userQuery,
+            clientPage,
+            userPage,
             selectedUsername = username,
             selectedUserDisplay = string.IsNullOrWhiteSpace(userDisplay) ? username : userDisplay
         });
+    }
+
+    private void ApplyClientPagination()
+    {
+        if (ClientResults.Count == 0)
+        {
+            ClientTotalPages = 0;
+            ClientPage = 1;
+            ClientPageResults = Array.Empty<ClientSummary>();
+            return;
+        }
+
+        ClientTotalPages = (int)Math.Ceiling(ClientResults.Count / (double)PageSize);
+        if (ClientPage < 1)
+        {
+            ClientPage = 1;
+        }
+        else if (ClientPage > ClientTotalPages)
+        {
+            ClientPage = ClientTotalPages;
+        }
+
+        var skip = (ClientPage - 1) * PageSize;
+        ClientPageResults = ClientResults.Skip(skip).Take(PageSize).ToList();
+    }
+
+    private void ApplyUserPagination()
+    {
+        if (UserResults.Count == 0)
+        {
+            UserTotalPages = 0;
+            UserPage = 1;
+            UserPageResults = Array.Empty<UserSearchResult>();
+            return;
+        }
+
+        UserTotalPages = (int)Math.Ceiling(UserResults.Count / (double)PageSize);
+        if (UserPage < 1)
+        {
+            UserPage = 1;
+        }
+        else if (UserPage > UserTotalPages)
+        {
+            UserPage = UserTotalPages;
+        }
+
+        var skip = (UserPage - 1) * PageSize;
+        UserPageResults = UserResults.Skip(skip).Take(PageSize).ToList();
     }
 }

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -72,9 +72,6 @@
     <div id="toastsHost">
         @RenderSection("Toasts", required: false)
     </div>
-    <div id="globalSpinner" class="fixed inset-0 bg-slate-900/40 flex items-center justify-center z-50 hidden">
-        <div class="w-16 h-16 border-4 border-slate-300 border-t-transparent rounded-full animate-spin"></div>
-    </div>
     <div id="pageScripts">
         @RenderSection("Scripts", required: false)
     </div>

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -270,16 +270,59 @@
 }
 
 .btn-subtle {
+    position: relative;
     border-radius: .75rem;
     background: rgba(255,255,255,.06);
     color: var(--kc-ink);
     padding: .5rem .9rem;
     border: 1px solid var(--kc-border-strong);
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    white-space: nowrap;
 }
 
     .btn-subtle:hover {
         background: rgba(255,255,255,.10);
     }
+
+.btn-subtle-active {
+    background: rgba(255,255,255,.14);
+    border-color: rgba(255,255,255,.3);
+    color: #e2e8f0;
+}
+
+.btn-loading {
+    pointer-events: none;
+    opacity: .85;
+    padding-right: 2.4rem;
+}
+
+.btn-loading::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: .75rem;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 9999px;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    animation: kc-btn-spin .65s linear infinite;
+    transform: translateY(-50%);
+    opacity: .9;
+}
+
+.btn-loading[aria-disabled="true"],
+.btn-loading[disabled] {
+    cursor: default;
+}
+
+@keyframes kc-btn-spin {
+    to {
+        transform: translateY(-50%) rotate(360deg);
+    }
+}
 
 /* ===== Forms / Tables ===== */
 .kc-disabled {
@@ -538,22 +581,33 @@
     }
 }
 
-/* Page transition animation */
-#app {
+/* Panel appearance animation */
+.soft-fade-panel {
     opacity: 0;
     transform: translateY(12px);
-    transition: opacity 0.4s cubic-bezier(0.22, 1, 0.36, 1), transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+    animation: kc-panel-in .45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
-body.page-transitioning #app {
-    opacity: 0;
-    transform: translateY(12px);
-    pointer-events: none;
+@keyframes kc-panel-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
-body.page-loaded #app {
-    opacity: 1;
-    transform: translateY(0);
+@media (prefers-reduced-motion: reduce) {
+    .btn-loading::after {
+        animation: none;
+    }
+    .soft-fade-panel {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
 }
 
 /* ===== Events filters ===== */


### PR DESCRIPTION
## Summary
- replace the full-screen loading spinner with button-scoped indicators and supporting styles/scripts
- add fade-in animations to conditional admin panels and paginate client/user search results on the UserClients page
- extend the page model to track pagination state and preserve it across actions

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb4943d0c832da88a2bbd1e490064