### PR TITLE
Enforce minimum query length on admin user clients page

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -41,6 +41,7 @@
                     <path d="m21 21-4.3-4.3" />
                 </svg>
                 <input name="clientQuery" value="@Model.ClientQuery" placeholder="Введите clientId"
+                       minlength="3"
                        class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
             </div>
             <input type="hidden" name="clientPage" value="1" />
@@ -82,7 +83,7 @@
                 @if (Model.ClientHasPreviousPage || Model.ClientHasNextPage)
                 {
                     <div class="flex items-center justify-between pt-2 text-sm text-slate-400">
-                        <div>Страница @Model.ClientPage</div>
+                        <div>Страница @Model.ClientPage из @Model.ClientTotalPages</div>
                         <div class="flex items-center gap-2">
                             @if (Model.ClientHasPreviousPage)
                             {
@@ -119,6 +120,10 @@
                     </div>
                 }
             }
+            else if (Model.ClientQueryTooShort)
+            {
+                <div class="text-sm text-slate-400">Введите минимум @Model.MinimumQueryLength символов для поиска.</div>
+            }
             else if (!string.IsNullOrWhiteSpace(Model.ClientQuery))
             {
                 <div class="text-sm text-slate-400">Клиенты не найдены.</div>
@@ -143,6 +148,7 @@
                     <path d="m21 21-4.3-4.3" />
                 </svg>
                 <input name="userQuery" value="@Model.UserQuery" placeholder="username, email или ФИО"
+                       minlength="3"
                        class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
             </div>
             <input type="hidden" name="userPage" value="1" />
@@ -184,7 +190,7 @@
                 @if (Model.UserHasPreviousPage || Model.UserHasNextPage)
                 {
                     <div class="flex items-center justify-between pt-2 text-sm text-slate-400">
-                        <div>Страница @Model.UserPage</div>
+                        <div>Страница @Model.UserPage из @Model.UserTotalPages</div>
                         <div class="flex items-center gap-2">
                             @if (Model.UserHasPreviousPage)
                             {
@@ -220,6 +226,10 @@
                         </div>
                     </div>
                 }
+            }
+            else if (Model.UserQueryTooShort)
+            {
+                <div class="text-sm text-slate-400">Введите минимум @Model.MinimumQueryLength символов для поиска.</div>
             }
             else if (!string.IsNullOrWhiteSpace(Model.UserQuery))
             {

--- a/Pages/Admin/UserClients.cshtml.cs
+++ b/Pages/Admin/UserClients.cshtml.cs
@@ -11,6 +11,7 @@ namespace Assistant.Pages.Admin;
 public sealed class UserClientsModel : PageModel
 {
     private const int PageSize = 5;
+    private const int MinimumQueryLengthValue = 3;
 
     private readonly RealmsService _realms;
     private readonly ClientsService _clients;
@@ -43,6 +44,9 @@ public sealed class UserClientsModel : PageModel
     public List<UserSearchResult> UserResults { get; private set; } = [];
     public List<ClientSummary> Assignments { get; private set; } = [];
 
+    public int ClientTotalPages { get; private set; }
+    public int UserTotalPages { get; private set; }
+
     public bool ClientHasNextPage { get; private set; }
     public bool UserHasNextPage { get; private set; }
 
@@ -57,6 +61,11 @@ public sealed class UserClientsModel : PageModel
 
     public bool ClientHasPreviousPage => ClientPage > 1;
     public bool UserHasPreviousPage => UserPage > 1;
+
+    public int MinimumQueryLength => MinimumQueryLengthValue;
+
+    public bool ClientQueryTooShort => IsQueryTooShort(ClientQuery);
+    public bool UserQueryTooShort => IsQueryTooShort(UserQuery);
 
     public async Task OnGetAsync(CancellationToken ct)
     {
@@ -91,14 +100,16 @@ public sealed class UserClientsModel : PageModel
         {
             ClientResults = [];
             ClientHasNextPage = false;
+            ClientTotalPages = 0;
             return;
         }
 
         var query = ClientQuery!.Trim();
-        if (query.Length == 0)
+        if (query.Length < MinimumQueryLengthValue)
         {
             ClientResults = [];
             ClientHasNextPage = false;
+            ClientTotalPages = 0;
             return;
         }
 
@@ -138,6 +149,7 @@ public sealed class UserClientsModel : PageModel
         {
             ClientResults = [];
             ClientHasNextPage = false;
+            ClientTotalPages = 0;
             return;
         }
 
@@ -148,6 +160,7 @@ public sealed class UserClientsModel : PageModel
             skip = (ClientPage - 1) * pageSize;
         }
 
+        ClientTotalPages = totalPages;
         ClientHasNextPage = ordered.Count > skip + pageSize;
         ClientResults = ordered
             .Skip(skip)
@@ -163,14 +176,16 @@ public sealed class UserClientsModel : PageModel
         {
             UserResults = [];
             UserHasNextPage = false;
+            UserTotalPages = 0;
             return;
         }
 
         var query = UserQuery!.Trim();
-        if (query.Length == 0)
+        if (query.Length < MinimumQueryLengthValue)
         {
             UserResults = [];
             UserHasNextPage = false;
+            UserTotalPages = 0;
             return;
         }
 
@@ -184,6 +199,7 @@ public sealed class UserClientsModel : PageModel
         {
             UserResults = [];
             UserHasNextPage = false;
+            UserTotalPages = 0;
             return;
         }
 
@@ -194,6 +210,7 @@ public sealed class UserClientsModel : PageModel
             skip = (UserPage - 1) * pageSize;
         }
 
+        UserTotalPages = totalPages;
         UserHasNextPage = results.Count > skip + pageSize;
         UserResults = results
             .Skip(skip)
@@ -299,5 +316,11 @@ public sealed class UserClientsModel : PageModel
             selectedUsername = username,
             selectedUserDisplay = string.IsNullOrWhiteSpace(userDisplay) ? username : userDisplay
         });
+    }
+
+    private static bool IsQueryTooShort(string? query)
+    {
+        var trimmed = query?.Trim();
+        return !string.IsNullOrEmpty(trimmed) && trimmed.Length < MinimumQueryLengthValue;
     }
 }


### PR DESCRIPTION
## Summary
- enforce a minimum search length for client and user lookups on the admin user clients page and show a validation hint when the query is too short
- surface the total number of pages in the client and user pagination headers

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cde171e8f8832d8c906fdffa5f18b1