### PR TITLE
Enable partial panel refresh on admin user clients page

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -25,7 +25,7 @@
 </div>
 
 <div class="grid gap-6 lg:grid-cols-2">
-    <section class="kc-card p-5">
+    <section class="kc-card p-5" id="clientPanel">
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Поиск клиента</h4>
             @if (!string.IsNullOrWhiteSpace(Model.SelectedClientId))
@@ -34,7 +34,7 @@
             }
         </div>
 
-        <form method="get" class="flex flex-col gap-3">
+        <form method="get" class="flex flex-col gap-3" data-soft-partial="#clientPanel">
             <div class="kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="11" cy="11" r="8" />
@@ -65,7 +65,7 @@
                             <div class="text-slate-100 font-medium">@client.ClientId</div>
                             <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @client.Realm</div>
                         </div>
-                        <form method="get" class="flex items-center gap-2">
+                        <form method="get" class="flex items-center gap-2" data-soft-partial="#clientPanel,#selectionPanels,#grantPanel">
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
@@ -87,7 +87,7 @@
                         <div class="flex items-center gap-2">
                             @if (Model.ClientHasPreviousPage)
                             {
-                                <form method="get" class="inline-flex">
+                                <form method="get" class="inline-flex" data-soft-partial="#clientPanel">
                                     <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@(Model.ClientPage - 1)" />
@@ -103,7 +103,7 @@
 
                             @if (Model.ClientHasNextPage)
                             {
-                                <form method="get" class="inline-flex">
+                                <form method="get" class="inline-flex" data-soft-partial="#clientPanel">
                                     <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@(Model.ClientPage + 1)" />
@@ -135,13 +135,13 @@
         </div>
     </section>
 
-    <section class="kc-card p-5">
+    <section class="kc-card p-5" id="userPanel">
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Поиск пользователя</h4>
             <span class="text-xs text-slate-400">Realm: @Model.PrimaryRealm</span>
         </div>
 
-        <form method="get" class="flex flex-col gap-3">
+        <form method="get" class="flex flex-col gap-3" data-soft-partial="#userPanel">
             <div class="kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="11" cy="11" r="8" />
@@ -172,7 +172,7 @@
                             <div class="text-slate-100 font-medium">@user.Username</div>
                             <div class="text-xs text-slate-400">@user.DisplayName</div>
                         </div>
-                        <form method="get" class="flex items-center gap-2">
+                        <form method="get" class="flex items-center gap-2" data-soft-partial="#userPanel,#selectionPanels,#grantPanel,#assignmentsPanel">
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
@@ -194,7 +194,7 @@
                         <div class="flex items-center gap-2">
                             @if (Model.UserHasPreviousPage)
                             {
-                                <form method="get" class="inline-flex">
+                                <form method="get" class="inline-flex" data-soft-partial="#userPanel">
                                     <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@Model.ClientPage" />
@@ -210,7 +210,7 @@
 
                             @if (Model.UserHasNextPage)
                             {
-                                <form method="get" class="inline-flex">
+                                <form method="get" class="inline-flex" data-soft-partial="#userPanel">
                                     <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@Model.ClientPage" />
@@ -243,97 +243,103 @@
     </section>
 </div>
 
-@if (Model.HasClientSelection || Model.HasUserSelection)
-{
-    <div class="grid gap-6 mt-6 lg:grid-cols-2">
-        @if (Model.HasClientSelection)
-        {
-            <div class="kc-card p-5">
-                <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный клиент</h4>
-                <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
-                    <div class="text-slate-100 font-medium text-lg">@Model.SelectedClientId</div>
-                    <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @Model.SelectedClientRealm</div>
-                </div>
-            </div>
-        }
-
-        @if (Model.HasUserSelection)
-        {
-            <div class="kc-card p-5">
-                <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный пользователь</h4>
-                <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
-                    <div class="text-slate-100 font-medium text-lg">@Model.SelectedUsername</div>
-                    <div class="text-xs text-slate-400">@Model.SelectedUserDisplay</div>
-                </div>
-            </div>
-        }
-    </div>
-}
-
-@if (Model.CanGrant)
-{
-    <div class="kc-card p-5 mt-6">
-        <h4 class="text-lg font-semibold text-slate-200">Предоставить доступ</h4>
-        <p class="text-sm text-slate-400 mt-2">
-            Клиент <span class="text-slate-200 font-medium">@Model.SelectedClientId</span> из realm
-            <span class="text-slate-200 font-medium">@Model.SelectedClientRealm</span> будет доступен пользователю
-            <span class="text-slate-200 font-medium">@Model.SelectedUsername</span>.
-        </p>
-
-        <form method="post" asp-page-handler="Grant" class="mt-4 flex flex-wrap items-center gap-3">
-            <input type="hidden" name="realm" value="@Model.SelectedClientRealm" />
-            <input type="hidden" name="clientId" value="@Model.SelectedClientId" />
-            <input type="hidden" name="clientName" value="@Model.SelectedClientName" />
-            <input type="hidden" name="username" value="@Model.SelectedUsername" />
-            <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
-            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
-            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
-            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
-            <input type="hidden" name="userPage" value="@Model.UserPage" />
-            <button type="submit" class="btn-primary">Назначить доступ</button>
-        </form>
-    </div>
-}
-
-@if (Model.HasUserSelection)
-{
-    <div class="kc-card p-5 mt-6">
-        <div class="flex items-center justify-between mb-4">
-            <h4 class="text-lg font-semibold text-slate-200">Клиенты пользователя @Model.SelectedUsername</h4>
-            <span class="text-xs text-slate-400">Всего: @Model.Assignments.Count</span>
-        </div>
-
-        @if (Model.Assignments.Any())
-        {
-            <div class="space-y-3">
-                @foreach (var client in Model.Assignments.OrderBy(c => c.Realm).ThenBy(c => c.ClientId))
-                {
-                    <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
-                        <div>
-                            <div class="text-slate-100 font-medium">@client.ClientId</div>
-                            <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @client.Realm</div>
-                        </div>
-                        <form method="post" asp-page-handler="Revoke" class="flex items-center gap-2">
-                            <input type="hidden" name="realm" value="@client.Realm" />
-                            <input type="hidden" name="clientId" value="@client.ClientId" />
-                            <input type="hidden" name="username" value="@Model.SelectedUsername" />
-                            <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
-                            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
-                            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
-                            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
-                            <input type="hidden" name="userPage" value="@Model.UserPage" />
-                            <button type="submit" class="btn-danger whitespace-nowrap">Удалить</button>
-                        </form>
+<div id="selectionPanels">
+    @if (Model.HasClientSelection || Model.HasUserSelection)
+    {
+        <div class="grid gap-6 mt-6 lg:grid-cols-2">
+            @if (Model.HasClientSelection)
+            {
+                <div class="kc-card p-5">
+                    <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный клиент</h4>
+                    <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
+                        <div class="text-slate-100 font-medium text-lg">@Model.SelectedClientId</div>
+                        <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @Model.SelectedClientRealm</div>
                     </div>
-                }
+                </div>
+            }
+
+            @if (Model.HasUserSelection)
+            {
+                <div class="kc-card p-5">
+                    <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный пользователь</h4>
+                    <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
+                        <div class="text-slate-100 font-medium text-lg">@Model.SelectedUsername</div>
+                        <div class="text-xs text-slate-400">@Model.SelectedUserDisplay</div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+<div id="grantPanel">
+    @if (Model.CanGrant)
+    {
+        <div class="kc-card p-5 mt-6">
+            <h4 class="text-lg font-semibold text-slate-200">Предоставить доступ</h4>
+            <p class="text-sm text-slate-400 mt-2">
+                Клиент <span class="text-slate-200 font-medium">@Model.SelectedClientId</span> из realm
+                <span class="text-slate-200 font-medium">@Model.SelectedClientRealm</span> будет доступен пользователю
+                <span class="text-slate-200 font-medium">@Model.SelectedUsername</span>.
+            </p>
+
+            <form method="post" asp-page-handler="Grant" class="mt-4 flex flex-wrap items-center gap-3" data-soft-partial="#grantPanel,#assignmentsPanel,#selectionPanels">
+                <input type="hidden" name="realm" value="@Model.SelectedClientRealm" />
+                <input type="hidden" name="clientId" value="@Model.SelectedClientId" />
+                <input type="hidden" name="clientName" value="@Model.SelectedClientName" />
+                <input type="hidden" name="username" value="@Model.SelectedUsername" />
+                <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
+                <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                <input type="hidden" name="userPage" value="@Model.UserPage" />
+                <button type="submit" class="btn-primary">Назначить доступ</button>
+            </form>
+        </div>
+    }
+</div>
+
+<div id="assignmentsPanel">
+    @if (Model.HasUserSelection)
+    {
+        <div class="kc-card p-5 mt-6">
+            <div class="flex items-center justify-between mb-4">
+                <h4 class="text-lg font-semibold text-slate-200">Клиенты пользователя @Model.SelectedUsername</h4>
+                <span class="text-xs text-slate-400">Всего: @Model.Assignments.Count</span>
             </div>
-        }
-        else
-        {
-            <div class="text-sm text-slate-400">Для выбранного пользователя пока нет назначенных клиентов.</div>
-        }
-    </div>
-}
+
+            @if (Model.Assignments.Any())
+            {
+                <div class="space-y-3">
+                    @foreach (var client in Model.Assignments.OrderBy(c => c.Realm).ThenBy(c => c.ClientId))
+                    {
+                        <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
+                            <div>
+                                <div class="text-slate-100 font-medium">@client.ClientId</div>
+                                <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @client.Realm</div>
+                            </div>
+                            <form method="post" asp-page-handler="Revoke" class="flex items-center gap-2" data-soft-partial="#assignmentsPanel,#grantPanel">
+                                <input type="hidden" name="realm" value="@client.Realm" />
+                                <input type="hidden" name="clientId" value="@client.ClientId" />
+                                <input type="hidden" name="username" value="@Model.SelectedUsername" />
+                                <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
+                                <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                                <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                                <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                                <input type="hidden" name="userPage" value="@Model.UserPage" />
+                                <button type="submit" class="btn-danger whitespace-nowrap">Удалить</button>
+                            </form>
+                        </div>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="text-sm text-slate-400">Для выбранного пользователя пока нет назначенных клиентов.</div>
+            }
+        </div>
+    }
+</div>
 
 @section Toasts {
     @if (TempData["FlashOk"] is string ok)

--- a/wwwroot/js/soft-navigation.js
+++ b/wwwroot/js/soft-navigation.js
@@ -340,6 +340,25 @@
         return url.toString();
     }
 
+    function getPartialTargets(form, submitter) {
+        if (!form) {
+            return null;
+        }
+        let submitterValue = null;
+        if (submitter && submitter.dataset) {
+            submitterValue = submitter.dataset.softPartial || null;
+        }
+        const formValue = form.dataset ? form.dataset.softPartial || null : null;
+        const source = submitterValue || formValue;
+        if (!source) {
+            return null;
+        }
+        return source
+            .split(',')
+            .map(part => part.trim())
+            .filter(part => part.length > 0);
+    }
+
     async function fetchAndSwap(url, options, hidePromise) {
         const requestUrl = url;
         const method = (options.method || 'GET').toUpperCase();
@@ -390,6 +409,45 @@
             return false;
         }
 
+        const partialTargets = Array.isArray(options.partialTargets) && options.partialTargets.length > 0
+            ? options.partialTargets
+            : null;
+        if (partialTargets) {
+            let replaced = false;
+            partialTargets.forEach(selector => {
+                if (!selector) {
+                    return;
+                }
+                const incoming = doc.querySelector(selector);
+                const current = document.querySelector(selector);
+                if (!incoming || !current) {
+                    return;
+                }
+                const imported = document.importNode(incoming, true);
+                current.replaceWith(imported);
+                executeSoftScripts(imported);
+                replaced = true;
+            });
+
+            if (!replaced) {
+                window.location.href = response.url || requestUrl;
+                return false;
+            }
+
+            refreshToasts(doc);
+            refreshScriptHost(doc);
+
+            const finalUrl = response.url || requestUrl;
+            if (options.pushState) {
+                history.pushState({ url: finalUrl }, '', finalUrl);
+            } else if (options.replaceState) {
+                history.replaceState({ url: finalUrl }, '', finalUrl);
+            }
+
+            updateAdminNavActive(finalUrl);
+            return true;
+        }
+
         const importedMain = document.importNode(newMain, true);
         if (hidePromise) {
             try {
@@ -431,6 +489,7 @@
         const trigger = options.trigger;
         delete options.trigger;
         const loadingTarget = trigger ? startButtonLoading(trigger) : null;
+        const usePartial = Array.isArray(options.partialTargets) && options.partialTargets.length > 0;
         if (!sameOrigin(url)) {
             if (loadingTarget) {
                 stopButtonLoading(loadingTarget);
@@ -439,13 +498,15 @@
             window.location.href = url;
             return;
         }
-        const hidePromise = hideApp();
+        const hidePromise = usePartial ? null : hideApp();
         let success;
         try {
             success = await fetchAndSwap(url, options, hidePromise);
             return success;
         } finally {
-            showApp();
+            if (!usePartial) {
+                showApp();
+            }
             if (loadingTarget) {
                 stopButtonLoading(loadingTarget);
             }
@@ -472,9 +533,10 @@
         event.preventDefault();
         const submitter = resolveSubmitter(event);
         const method = (form.method || 'GET').toUpperCase();
+        const partialTargets = getPartialTargets(form, submitter);
         if (method === 'GET') {
             const url = buildGetUrl(form, submitter);
-            handleNavigation(url, { method: 'GET', pushState: true, trigger: submitter });
+            handleNavigation(url, { method: 'GET', pushState: true, trigger: submitter, partialTargets });
             return;
         }
         const formData = new FormData(form);
@@ -483,7 +545,7 @@
             formData.append(submitter.name, submitValue);
         }
         const action = form.getAttribute('action') || window.location.href;
-        handleNavigation(action, { method, body: formData, pushState: true, trigger: submitter });
+        handleNavigation(action, { method, body: formData, pushState: true, trigger: submitter, partialTargets });
     }
 
     function onPopState(event) {


### PR DESCRIPTION
## Summary
- scope the admin user client forms with partial targets so only affected panels refresh
- extend the soft-navigation helper to replace partial fragments, update toast host, and skip full-page transitions for those submits

## Testing
- not run (dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68cde3978724832dbe6cb6155cd3b178