### PR TITLE
Make admin panels load independently

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -25,7 +25,7 @@
 </div>
 
 <div class="grid gap-6 lg:grid-cols-2">
-    <section class="kc-card p-5">
+    <section class="kc-card p-5" id="clientPanel" data-soft-panel>
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Поиск клиента</h4>
             @if (!string.IsNullOrWhiteSpace(Model.SelectedClientId))
@@ -34,7 +34,7 @@
             }
         </div>
 
-        <form method="get" class="flex flex-col gap-3">
+        <form method="get" class="flex flex-col gap-3" data-soft-targets="#clientPanel,#selectionSummary,#grantPanel,#selectionState">
             <div class="kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="11" cy="11" r="8" />
@@ -47,8 +47,8 @@
             <input type="hidden" name="clientPage" value="1" />
             <input type="hidden" name="userPage" value="@Model.UserPage" />
             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
-            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
-            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" data-soft-sync="selectedUsername" />
+            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" data-soft-sync="selectedUserDisplay" />
             <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
             <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
             <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
@@ -65,7 +65,7 @@
                             <div class="text-slate-100 font-medium">@client.ClientId</div>
                             <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @client.Realm</div>
                         </div>
-                        <form method="get" class="flex items-center gap-2">
+                        <form method="get" class="flex items-center gap-2" data-soft-targets="#clientPanel,#selectionSummary,#grantPanel,#selectionState">
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
@@ -73,8 +73,8 @@
                             <input type="hidden" name="selectedClientId" value="@client.ClientId" />
                             <input type="hidden" name="selectedClientRealm" value="@client.Realm" />
                             <input type="hidden" name="selectedClientName" value="@client.Name" />
-                            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
-                            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" data-soft-sync="selectedUsername" />
+                            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" data-soft-sync="selectedUserDisplay" />
                             <button type="submit" class="btn-subtle whitespace-nowrap">Выбрать</button>
                         </form>
                     </div>
@@ -87,7 +87,7 @@
                         <div class="flex items-center gap-2">
                             @if (Model.ClientHasPreviousPage)
                             {
-                                <form method="get" class="inline-flex">
+                                <form method="get" class="inline-flex" data-soft-targets="#clientPanel,#selectionSummary,#grantPanel,#selectionState">
                                     <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@(Model.ClientPage - 1)" />
@@ -95,15 +95,15 @@
                                     <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
                                     <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
                                     <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
-                                    <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
-                                    <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                                    <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" data-soft-sync="selectedUsername" />
+                                    <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" data-soft-sync="selectedUserDisplay" />
                                     <button type="submit" class="btn-subtle whitespace-nowrap">← Назад</button>
                                 </form>
                             }
 
                             @if (Model.ClientHasNextPage)
                             {
-                                <form method="get" class="inline-flex">
+                                <form method="get" class="inline-flex" data-soft-targets="#clientPanel,#selectionSummary,#grantPanel,#selectionState">
                                     <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@(Model.ClientPage + 1)" />
@@ -111,8 +111,8 @@
                                     <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
                                     <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
                                     <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
-                                    <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
-                                    <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                                    <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" data-soft-sync="selectedUsername" />
+                                    <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" data-soft-sync="selectedUserDisplay" />
                                     <button type="submit" class="btn-subtle whitespace-nowrap">Вперёд →</button>
                                 </form>
                             }
@@ -135,13 +135,13 @@
         </div>
     </section>
 
-    <section class="kc-card p-5">
+    <section class="kc-card p-5" id="userPanel" data-soft-panel>
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Поиск пользователя</h4>
             <span class="text-xs text-slate-400">Realm: @Model.PrimaryRealm</span>
         </div>
 
-        <form method="get" class="flex flex-col gap-3">
+        <form method="get" class="flex flex-col gap-3" data-soft-targets="#userPanel,#selectionSummary,#grantPanel,#assignmentsPanel,#selectionState">
             <div class="kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="11" cy="11" r="8" />
@@ -154,11 +154,11 @@
             <input type="hidden" name="userPage" value="1" />
             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
-            <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
-            <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
-            <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
-            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
-            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+            <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" data-soft-sync="selectedClientId" />
+            <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" data-soft-sync="selectedClientRealm" />
+            <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" data-soft-sync="selectedClientName" />
+            <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" data-soft-sync="selectedUsername" />
+            <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" data-soft-sync="selectedUserDisplay" />
             <button type="submit" class="btn-subtle self-start">Найти пользователя</button>
         </form>
 
@@ -172,14 +172,14 @@
                             <div class="text-slate-100 font-medium">@user.Username</div>
                             <div class="text-xs text-slate-400">@user.DisplayName</div>
                         </div>
-                        <form method="get" class="flex items-center gap-2">
+                        <form method="get" class="flex items-center gap-2" data-soft-targets="#userPanel,#selectionSummary,#grantPanel,#assignmentsPanel,#selectionState">
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
                             <input type="hidden" name="userPage" value="@Model.UserPage" />
-                            <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
-                            <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
-                            <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
+                            <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" data-soft-sync="selectedClientId" />
+                            <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" data-soft-sync="selectedClientRealm" />
+                            <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" data-soft-sync="selectedClientName" />
                             <input type="hidden" name="selectedUsername" value="@user.Username" />
                             <input type="hidden" name="selectedUserDisplay" value="@user.DisplayName" />
                             <button type="submit" class="btn-subtle whitespace-nowrap">Выбрать</button>
@@ -194,32 +194,32 @@
                         <div class="flex items-center gap-2">
                             @if (Model.UserHasPreviousPage)
                             {
-                                <form method="get" class="inline-flex">
+                                <form method="get" class="inline-flex" data-soft-targets="#userPanel,#selectionSummary,#grantPanel,#assignmentsPanel,#selectionState">
                                     <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@Model.ClientPage" />
                                     <input type="hidden" name="userPage" value="@(Model.UserPage - 1)" />
-                                    <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
-                                    <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
-                                    <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
-                                    <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
-                                    <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                                    <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" data-soft-sync="selectedClientId" />
+                                    <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" data-soft-sync="selectedClientRealm" />
+                                    <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" data-soft-sync="selectedClientName" />
+                                    <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" data-soft-sync="selectedUsername" />
+                                    <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" data-soft-sync="selectedUserDisplay" />
                                     <button type="submit" class="btn-subtle whitespace-nowrap">← Назад</button>
                                 </form>
                             }
 
                             @if (Model.UserHasNextPage)
                             {
-                                <form method="get" class="inline-flex">
+                                <form method="get" class="inline-flex" data-soft-targets="#userPanel,#selectionSummary,#grantPanel,#assignmentsPanel,#selectionState">
                                     <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@Model.ClientPage" />
                                     <input type="hidden" name="userPage" value="@(Model.UserPage + 1)" />
-                                    <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
-                                    <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
-                                    <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
-                                    <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
-                                    <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                                    <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" data-soft-sync="selectedClientId" />
+                                    <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" data-soft-sync="selectedClientRealm" />
+                                    <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" data-soft-sync="selectedClientName" />
+                                    <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" data-soft-sync="selectedUsername" />
+                                    <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" data-soft-sync="selectedUserDisplay" />
                                     <button type="submit" class="btn-subtle whitespace-nowrap">Вперёд →</button>
                                 </form>
                             }
@@ -243,97 +243,132 @@
     </section>
 </div>
 
-@if (Model.HasClientSelection || Model.HasUserSelection)
-{
-    <div class="grid gap-6 mt-6 lg:grid-cols-2">
-        @if (Model.HasClientSelection)
-        {
-            <div class="kc-card p-5">
-                <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный клиент</h4>
-                <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
-                    <div class="text-slate-100 font-medium text-lg">@Model.SelectedClientId</div>
-                    <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @Model.SelectedClientRealm</div>
-                </div>
-            </div>
-        }
-
-        @if (Model.HasUserSelection)
-        {
-            <div class="kc-card p-5">
-                <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный пользователь</h4>
-                <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
-                    <div class="text-slate-100 font-medium text-lg">@Model.SelectedUsername</div>
-                    <div class="text-xs text-slate-400">@Model.SelectedUserDisplay</div>
-                </div>
-            </div>
-        }
-    </div>
-}
-
-@if (Model.CanGrant)
-{
-    <div class="kc-card p-5 mt-6">
-        <h4 class="text-lg font-semibold text-slate-200">Предоставить доступ</h4>
-        <p class="text-sm text-slate-400 mt-2">
-            Клиент <span class="text-slate-200 font-medium">@Model.SelectedClientId</span> из realm
-            <span class="text-slate-200 font-medium">@Model.SelectedClientRealm</span> будет доступен пользователю
-            <span class="text-slate-200 font-medium">@Model.SelectedUsername</span>.
-        </p>
-
-        <form method="post" asp-page-handler="Grant" class="mt-4 flex flex-wrap items-center gap-3">
-            <input type="hidden" name="realm" value="@Model.SelectedClientRealm" />
-            <input type="hidden" name="clientId" value="@Model.SelectedClientId" />
-            <input type="hidden" name="clientName" value="@Model.SelectedClientName" />
-            <input type="hidden" name="username" value="@Model.SelectedUsername" />
-            <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
-            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
-            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
-            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
-            <input type="hidden" name="userPage" value="@Model.UserPage" />
-            <button type="submit" class="btn-primary">Назначить доступ</button>
-        </form>
-    </div>
-}
-
-@if (Model.HasUserSelection)
-{
-    <div class="kc-card p-5 mt-6">
-        <div class="flex items-center justify-between mb-4">
-            <h4 class="text-lg font-semibold text-slate-200">Клиенты пользователя @Model.SelectedUsername</h4>
-            <span class="text-xs text-slate-400">Всего: @Model.Assignments.Count</span>
-        </div>
-
-        @if (Model.Assignments.Any())
-        {
-            <div class="space-y-3">
-                @foreach (var client in Model.Assignments.OrderBy(c => c.Realm).ThenBy(c => c.ClientId))
-                {
-                    <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
-                        <div>
-                            <div class="text-slate-100 font-medium">@client.ClientId</div>
-                            <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @client.Realm</div>
-                        </div>
-                        <form method="post" asp-page-handler="Revoke" class="flex items-center gap-2">
-                            <input type="hidden" name="realm" value="@client.Realm" />
-                            <input type="hidden" name="clientId" value="@client.ClientId" />
-                            <input type="hidden" name="username" value="@Model.SelectedUsername" />
-                            <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
-                            <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
-                            <input type="hidden" name="userQuery" value="@Model.UserQuery" />
-                            <input type="hidden" name="clientPage" value="@Model.ClientPage" />
-                            <input type="hidden" name="userPage" value="@Model.UserPage" />
-                            <button type="submit" class="btn-danger whitespace-nowrap">Удалить</button>
-                        </form>
+<div id="selectionSummary" class="mt-6">
+    @if (Model.HasClientSelection || Model.HasUserSelection)
+    {
+        <div class="grid gap-6 lg:grid-cols-2">
+            @if (Model.HasClientSelection)
+            {
+                <div class="kc-card p-5">
+                    <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный клиент</h4>
+                    <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
+                        <div class="text-slate-100 font-medium text-lg">@Model.SelectedClientId</div>
+                        <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @Model.SelectedClientRealm</div>
                     </div>
-                }
+                </div>
+            }
+
+            @if (Model.HasUserSelection)
+            {
+                <div class="kc-card p-5">
+                    <h4 class="text-lg font-semibold text-slate-200 mb-3">Выбранный пользователь</h4>
+                    <div class="rounded-xl border border-white/5 bg-white/5 px-4 py-3">
+                        <div class="text-slate-100 font-medium text-lg">@Model.SelectedUsername</div>
+                        <div class="text-xs text-slate-400">@Model.SelectedUserDisplay</div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+<div id="grantPanel" class="mt-6">
+    @if (Model.CanGrant)
+    {
+        <div class="kc-card p-5">
+            <h4 class="text-lg font-semibold text-slate-200">Предоставить доступ</h4>
+            <p class="text-sm text-slate-400 mt-2">
+                Клиент <span class="text-slate-200 font-medium">@Model.SelectedClientId</span> из realm
+                <span class="text-slate-200 font-medium">@Model.SelectedClientRealm</span> будет доступен пользователю
+                <span class="text-slate-200 font-medium">@Model.SelectedUsername</span>.
+            </p>
+
+            <form method="post" asp-page-handler="Grant" class="mt-4 flex flex-wrap items-center gap-3">
+                <input type="hidden" name="realm" value="@Model.SelectedClientRealm" />
+                <input type="hidden" name="clientId" value="@Model.SelectedClientId" />
+                <input type="hidden" name="clientName" value="@Model.SelectedClientName" />
+                <input type="hidden" name="username" value="@Model.SelectedUsername" />
+                <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
+                <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                <input type="hidden" name="userPage" value="@Model.UserPage" />
+                <button type="submit" class="btn-primary">Назначить доступ</button>
+            </form>
+        </div>
+    }
+</div>
+
+<div id="assignmentsPanel" class="mt-6">
+    @if (Model.HasUserSelection)
+    {
+        <div class="kc-card p-5">
+            <div class="flex items-center justify-between mb-4">
+                <h4 class="text-lg font-semibold text-slate-200">Клиенты пользователя @Model.SelectedUsername</h4>
+                <span class="text-xs text-slate-400">Всего: @Model.Assignments.Count</span>
             </div>
-        }
-        else
-        {
-            <div class="text-sm text-slate-400">Для выбранного пользователя пока нет назначенных клиентов.</div>
-        }
-    </div>
-}
+
+            @if (Model.Assignments.Any())
+            {
+                <div class="space-y-3">
+                    @foreach (var client in Model.Assignments.OrderBy(c => c.Realm).ThenBy(c => c.ClientId))
+                    {
+                        <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
+                            <div>
+                                <div class="text-slate-100 font-medium">@client.ClientId</div>
+                                <div class="text-xs text-slate-400 uppercase tracking-wide">Realm: @client.Realm</div>
+                            </div>
+                            <form method="post" asp-page-handler="Revoke" class="flex items-center gap-2">
+                                <input type="hidden" name="realm" value="@client.Realm" />
+                                <input type="hidden" name="clientId" value="@client.ClientId" />
+                                <input type="hidden" name="username" value="@Model.SelectedUsername" />
+                                <input type="hidden" name="userDisplay" value="@Model.SelectedUserDisplay" />
+                                <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                                <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                                <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                                <input type="hidden" name="userPage" value="@Model.UserPage" />
+                                <button type="submit" class="btn-danger whitespace-nowrap">Удалить</button>
+                            </form>
+                        </div>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="text-sm text-slate-400">Для выбранного пользователя пока нет назначенных клиентов.</div>
+            }
+        </div>
+    }
+</div>
+
+<div id="selectionState" hidden
+     data-selected-client-id="@(Model.SelectedClientId ?? string.Empty)"
+     data-selected-client-realm="@(Model.SelectedClientRealm ?? string.Empty)"
+     data-selected-client-name="@(Model.SelectedClientName ?? string.Empty)"
+     data-selected-username="@(Model.SelectedUsername ?? string.Empty)"
+     data-selected-user-display="@(Model.SelectedUserDisplay ?? string.Empty)">
+    <script data-soft-nav>
+        (function () {
+            const host = document.getElementById('selectionState');
+            if (!host) {
+                return;
+            }
+            const sync = (key, value) => {
+                document.querySelectorAll(`[data-soft-sync="${key}"]`).forEach(element => {
+                    if (element instanceof HTMLInputElement) {
+                        element.value = value || '';
+                    }
+                });
+            };
+            const dataset = host.dataset;
+            sync('selectedClientId', dataset.selectedClientId || '');
+            sync('selectedClientRealm', dataset.selectedClientRealm || '');
+            sync('selectedClientName', dataset.selectedClientName || '');
+            sync('selectedUsername', dataset.selectedUsername || '');
+            sync('selectedUserDisplay', dataset.selectedUserDisplay || '');
+        })();
+    </script>
+</div>
 
 @section Toasts {
     @if (TempData["FlashOk"] is string ok)

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -603,6 +603,48 @@ body.page-loaded #app {
     transform: translateY(0);
 }
 
+[data-soft-panel] {
+    position: relative;
+}
+
+[data-soft-panel][data-soft-loading="true"] {
+    pointer-events: none;
+}
+
+[data-soft-panel][data-soft-loading="true"]::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    border-radius: inherit;
+    z-index: 10;
+}
+
+[data-soft-panel][data-soft-loading="true"]::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 2.5rem;
+    height: 2.5rem;
+    margin-top: -1.25rem;
+    margin-left: -1.25rem;
+    border-radius: 9999px;
+    border: 3px solid rgba(148, 163, 184, 0.35);
+    border-top-color: rgba(226, 232, 240, 0.85);
+    z-index: 11;
+    animation: soft-panel-spin 0.8s linear infinite;
+}
+
+@keyframes soft-panel-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 /* ===== Events filters ===== */
 .event-filters {
     width: 100%;


### PR DESCRIPTION
## Summary
- add partial soft navigation support to update specific panels and track per-panel loaders
- restructure `/Admin/UserClients` markup to target panel updates and keep selection state in sync
- style soft-loading panels with an overlay spinner to keep animations scoped to each card

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cde87ba714832d98c41fca2d9a1173