### PR TITLE
Use fade transition for admin selection panels

### DIFF
--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -489,6 +489,10 @@
     .fade-enter-active, .fade-leave-active {
         transition: none !important;
     }
+
+    [data-soft-panel]::before {
+        transition: none !important;
+    }
 }
 
 
@@ -607,42 +611,24 @@ body.page-loaded #app {
     position: relative;
 }
 
-[data-soft-panel][data-soft-loading="true"] {
-    pointer-events: none;
-}
-
-[data-soft-panel][data-soft-loading="true"]::before {
+[data-soft-panel]::before {
     content: "";
     position: absolute;
     inset: 0;
     background: rgba(15, 23, 42, 0.55);
     border-radius: inherit;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .18s ease;
     z-index: 10;
 }
 
-[data-soft-panel][data-soft-loading="true"]::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 2.5rem;
-    height: 2.5rem;
-    margin-top: -1.25rem;
-    margin-left: -1.25rem;
-    border-radius: 9999px;
-    border: 3px solid rgba(148, 163, 184, 0.35);
-    border-top-color: rgba(226, 232, 240, 0.85);
-    z-index: 11;
-    animation: soft-panel-spin 0.8s linear infinite;
+[data-soft-panel][data-soft-loading="true"] {
+    pointer-events: none;
 }
 
-@keyframes soft-panel-spin {
-    from {
-        transform: rotate(0deg);
-    }
-    to {
-        transform: rotate(360deg);
-    }
+[data-soft-panel][data-soft-loading="true"]::before {
+    opacity: 1;
 }
 
 /* ===== Events filters ===== */


### PR DESCRIPTION
## Summary
- replace the loading spinner on admin selection panels with the existing fade overlay
- respect reduced motion preferences for the updated panel transition

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdeefcf5e4832d80270807cddde54c