### PR TITLE
Adjust grid alignment for UserClients sections

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -24,7 +24,7 @@
     </div>
 </div>
 
-<div class="grid gap-6 lg:grid-cols-2">
+<div class="grid gap-6 lg:grid-cols-2 items-start">
     <section class="kc-card p-5">
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Поиск клиента</h4>


### PR DESCRIPTION
## Summary
- prevent grid items on the UserClients page from stretching to equal heights so each search section matches its own content

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf669a8a0832d84a971a1f57ebdf1