### PR TITLE
Add scoped soft transitions for all UserClients actions

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -25,7 +25,7 @@
 </div>
 
 <div class="grid gap-6 lg:grid-cols-2 items-start">
-    <section id="clientSearchPanel" class="kc-card p-5">
+    <section id="clientSearchPanel" class="kc-card p-5" data-soft-transition="#clientSearchPanel">
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Поиск клиента</h4>
             @if (!string.IsNullOrWhiteSpace(Model.SelectedClientId))
@@ -135,7 +135,7 @@
         </div>
     </section>
 
-    <section class="kc-card p-5">
+    <section id="userSearchPanel" class="kc-card p-5" data-soft-transition="#userSearchPanel">
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Поиск пользователя</h4>
             <span class="text-xs text-slate-400">Realm: @Model.PrimaryRealm</span>
@@ -272,7 +272,7 @@
 
 @if (Model.CanGrant)
 {
-    <div class="kc-card p-5 mt-6">
+    <div id="grantAccessPanel" class="kc-card p-5 mt-6" data-soft-transition="#grantAccessPanel">
         <h4 class="text-lg font-semibold text-slate-200">Предоставить доступ</h4>
         <p class="text-sm text-slate-400 mt-2">
             Клиент <span class="text-slate-200 font-medium">@Model.SelectedClientId</span> из realm
@@ -297,7 +297,7 @@
 
 @if (Model.HasUserSelection)
 {
-    <div class="kc-card p-5 mt-6">
+    <div id="userAssignmentsPanel" class="kc-card p-5 mt-6" data-soft-transition="#userAssignmentsPanel">
         <div class="flex items-center justify-between mb-4">
             <h4 class="text-lg font-semibold text-slate-200">Клиенты пользователя @Model.SelectedUsername</h4>
             <span class="text-xs text-slate-400">Всего: @Model.Assignments.Count</span>


### PR DESCRIPTION
## Summary
- scope soft navigation transitions to the client search, user search, grant access, and user assignments cards
- ensure every button on the UserClients page only animates the block it belongs to

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cefb9c5ad4832dbd6a79c9f5448ed6