### PR TITLE
Stop scrolling to top after user selection

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -172,7 +172,7 @@
                             <div class="text-slate-100 font-medium">@user.Username</div>
                             <div class="text-xs text-slate-400">@user.DisplayName</div>
                         </div>
-                        <form method="get" class="flex items-center gap-2" data-soft-transition="#userSearchPanel,#selectedUserCard,#grantAccessPanel,#userAssignmentsPanel">
+                        <form method="get" class="flex items-center gap-2" data-soft-transition="#userSearchPanel,#selectedUserCard,#grantAccessPanel,#userAssignmentsPanel" data-soft-scroll="false">
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />

--- a/wwwroot/js/soft-navigation.js
+++ b/wwwroot/js/soft-navigation.js
@@ -140,6 +140,36 @@
         return null;
     }
 
+    function resolveScrollPreference(form, submitter) {
+        function parse(value) {
+            if (typeof value !== 'string') {
+                return null;
+            }
+            const normalized = value.trim().toLowerCase();
+            if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+                return true;
+            }
+            if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+                return false;
+            }
+            return null;
+        }
+
+        const submitterPreference = submitter && submitter.dataset ? parse(submitter.dataset.softScroll) : null;
+        if (submitterPreference !== null) {
+            return submitterPreference;
+        }
+
+        if (form && form.dataset) {
+            const formPreference = parse(form.dataset.softScroll);
+            if (formPreference !== null) {
+                return formPreference;
+            }
+        }
+
+        return null;
+    }
+
     function resolveLoadableElement(element) {
         if (!element || !(element instanceof HTMLElement)) {
             return null;
@@ -591,10 +621,15 @@
         event.preventDefault();
         const submitter = resolveSubmitter(event);
         const method = (form.method || 'GET').toUpperCase();
+        const transitionTarget = resolveTransitionTarget(form, submitter);
+        const scrollPreference = resolveScrollPreference(form, submitter);
+        const baseOptions = { pushState: true, trigger: submitter, transition: transitionTarget };
+        if (scrollPreference !== null) {
+            baseOptions.scroll = scrollPreference;
+        }
         if (method === 'GET') {
             const url = buildGetUrl(form, submitter);
-            const transitionTarget = resolveTransitionTarget(form, submitter);
-            handleNavigation(url, { method: 'GET', pushState: true, trigger: submitter, transition: transitionTarget });
+            handleNavigation(url, Object.assign({ method: 'GET' }, baseOptions));
             return;
         }
         const formData = new FormData(form);
@@ -603,8 +638,7 @@
             formData.append(submitter.name, submitValue);
         }
         const action = form.getAttribute('action') || window.location.href;
-        const transitionTarget = resolveTransitionTarget(form, submitter);
-        handleNavigation(action, { method, body: formData, pushState: true, trigger: submitter, transition: transitionTarget });
+        handleNavigation(action, Object.assign({ method, body: formData }, baseOptions));
     }
 
     function onPopState(event) {


### PR DESCRIPTION
## Summary
- add support for opting out of automatic scroll-to-top in soft navigation forms
- mark the user selection form on the UserClients page to keep the current scroll position after submission

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf17dcbe88832da2178120a4876c68