### PR TITLE
Stop scrolling to top after user selection

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -172,7 +172,7 @@
                             <div class="text-slate-100 font-medium">@user.Username</div>
                             <div class="text-xs text-slate-400">@user.DisplayName</div>
                         </div>
-                        <form method="get" class="flex items-center gap-2" data-soft-transition="#userSearchPanel,#selectedUserCard,#grantAccessPanel,#userAssignmentsPanel">
+                        <form method="get" class="flex items-center gap-2" data-soft-transition="#userSearchPanel,#selectedUserCard,#grantAccessPanel,#userAssignmentsPanel" data-soft-scroll="false">
                             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />


### PR DESCRIPTION
## Summary
- add support for opting out of automatic scroll-to-top in soft navigation forms
- mark the user selection form on the UserClients page to keep the current scroll position after submission
- restore the previous scroll position when a soft navigation requests no scrolling so the page stays put

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf17dcbe88832da2178120a4876c68