### PR TITLE
feat: soften soft navigation animation

### DIFF
--- a/wwwroot/js/soft-navigation.js
+++ b/wwwroot/js/soft-navigation.js
@@ -4,7 +4,140 @@
         return;
     }
 
+    let app = null;
+    let appAnimationState = null;
+
+    function cancelAppAnimation() {
+        if (!appAnimationState) {
+            return;
+        }
+        const { animation, cleanup } = appAnimationState;
+        appAnimationState = null;
+        if (animation) {
+            try {
+                animation.cancel();
+            } catch (_) {
+                // Ignore animation cancellation errors.
+            }
+        }
+        if (typeof cleanup === 'function') {
+            try {
+                cleanup();
+            } catch (_) {
+                // Ignore cleanup errors.
+            }
+        }
+    }
+
+    function animateAppVisibility(shouldShow) {
+        if (!app || typeof app.animate !== 'function') {
+            return null;
+        }
+        if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            return null;
+        }
+
+        if (appAnimationState) {
+            cancelAppAnimation();
+        }
+
+        const target = app;
+        const computed = window.getComputedStyle(target);
+        const currentOpacity = parseFloat(computed.opacity);
+        const startOpacity = isNaN(currentOpacity) ? (shouldShow ? 0 : 1) : currentOpacity;
+        const startTransform = computed.transform && computed.transform !== 'none'
+            ? computed.transform
+            : (shouldShow ? 'translateY(12px)' : 'translateY(0px)');
+        const endTransform = shouldShow ? 'translateY(0px)' : 'translateY(12px)';
+        const endOpacity = shouldShow ? 1 : 0;
+
+        const previousTransition = target.style.transition;
+        target.style.transition = 'none';
+
+        const previousWillChange = target.style.willChange;
+        let willChangeOverridden = false;
+        if (!previousWillChange) {
+            target.style.willChange = 'opacity, transform';
+            willChangeOverridden = true;
+        }
+
+        const midShowOpacity = Math.min(1, Math.max(startOpacity, 0.85));
+        const midHideOpacity = Math.min(1, Math.max(endOpacity, startOpacity - 0.15));
+        const keyframes = shouldShow
+            ? [
+                { opacity: startOpacity, transform: startTransform },
+                { opacity: midShowOpacity, transform: 'translateY(-4px)', offset: 0.7 },
+                { opacity: endOpacity, transform: endTransform }
+            ]
+            : [
+                { opacity: startOpacity, transform: startTransform },
+                { opacity: midHideOpacity, transform: 'translateY(6px)', offset: 0.35 },
+                { opacity: endOpacity, transform: endTransform }
+            ];
+
+        let animation;
+        try {
+            animation = target.animate(keyframes, {
+                duration: shouldShow ? 460 : 360,
+                easing: shouldShow ? 'cubic-bezier(0.33, 1, 0.68, 1)' : 'cubic-bezier(0.4, 0, 0.2, 1)',
+                fill: 'forwards'
+            });
+        } catch (_) {
+            target.style.transition = previousTransition;
+            if (willChangeOverridden) {
+                target.style.willChange = previousWillChange;
+            }
+            return null;
+        }
+
+        let cleaned = false;
+        const cleanup = () => {
+            if (cleaned) {
+                return;
+            }
+            cleaned = true;
+            target.style.transition = previousTransition;
+            if (willChangeOverridden) {
+                target.style.willChange = previousWillChange;
+            }
+        };
+
+        const state = { animation, cleanup };
+        appAnimationState = state;
+
+        const promise = new Promise(resolve => {
+            let resolved = false;
+            const finalize = () => {
+                if (resolved) {
+                    return;
+                }
+                resolved = true;
+                if (appAnimationState === state) {
+                    appAnimationState = null;
+                }
+                cleanup();
+                resolve();
+            };
+
+            animation.addEventListener('finish', () => {
+                if (typeof animation.commitStyles === 'function') {
+                    try {
+                        animation.commitStyles();
+                    } catch (_) {
+                        // Ignore browsers that throw for commitStyles.
+                    }
+                }
+                animation.cancel();
+                finalize();
+            }, { once: true });
+
+            animation.addEventListener('cancel', finalize, { once: true });
+        });
+        return promise;
+    }
+
     function showApp() {
+        animateAppVisibility(true);
         requestAnimationFrame(() => {
             body.classList.remove('page-transitioning');
             body.classList.add('page-loaded');
@@ -12,18 +145,19 @@
     }
 
     function hideApp() {
+        const animationPromise = app ? animateAppVisibility(false) : null;
         body.classList.add('page-transitioning');
         body.classList.remove('page-loaded');
         if (!app) {
             return Promise.resolve();
         }
-        return waitForTransition(app, 'opacity');
+        return animationPromise || waitForTransition(app, 'opacity');
     }
 
     showApp();
 
     const root = document.querySelector('[data-soft-root]');
-    let app = document.getElementById('app');
+    app = document.getElementById('app');
     const toastsHost = document.getElementById('toastsHost');
     const scriptHost = document.getElementById('pageScripts');
     const ADMIN_ACTIVE_CLASSES = ['bg-white/10', 'text-white', 'shadow-[0_0_0_1px_rgba(255,255,255,0.08)]'];
@@ -506,6 +640,7 @@
                 // Ignore transition wait failures and continue swapping.
             }
         }
+        cancelAppAnimation();
         app.replaceWith(importedMain);
         app = importedMain;
         executeSoftScripts(app);


### PR DESCRIPTION
## Summary
- replace the hard class-based page transition with a softer Web Animations API sequence in `soft-navigation.js`
- add cancellation and cleanup helpers so animations can be interrupted safely and restore inline styles when swapping app roots

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf482c9658832db0115122522e593c