### PR TITLE
Fix pagination totals in UserClients search

### DIFF
--- a/Pages/Admin/UserClients.cshtml.cs
+++ b/Pages/Admin/UserClients.cshtml.cs
@@ -12,6 +12,7 @@ public sealed class UserClientsModel : PageModel
 {
     private const int PageSize = 5;
     private const int MinimumQueryLengthValue = 3;
+    private const int SearchFetchLimit = 200;
 
     private readonly RealmsService _realms;
     private readonly ClientsService _clients;
@@ -118,7 +119,7 @@ public sealed class UserClientsModel : PageModel
 
         var pageSize = PageSize;
         var skip = (ClientPage - 1) * pageSize;
-        var maxToFetch = skip + pageSize + 1;
+        var fetchLimit = SearchFetchLimit;
 
         foreach (var realm in realms)
         {
@@ -127,7 +128,7 @@ public sealed class UserClientsModel : PageModel
                 continue;
             }
 
-            var hits = await _clients.SearchClientsAsync(realm.Realm!, query, 0, maxToFetch, ct);
+            var hits = await _clients.SearchClientsAsync(realm.Realm!, query, 0, fetchLimit, ct);
             foreach (var hit in hits)
             {
                 list.Add(new ClientSummary(
@@ -191,9 +192,9 @@ public sealed class UserClientsModel : PageModel
 
         var pageSize = PageSize;
         var skip = (UserPage - 1) * pageSize;
-        var maxToFetch = skip + pageSize + 1;
+        var fetchLimit = SearchFetchLimit;
 
-        var results = await _users.SearchUsersAsync(query, 0, maxToFetch, ct);
+        var results = await _users.SearchUsersAsync(query, 0, fetchLimit, ct);
 
         if (results.Count == 0)
         {


### PR DESCRIPTION
## Summary
- add a shared fetch limit constant for the UserClients page model
- request the full batch of search results for clients and users so the total pages count reflects the actual end page

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4cace2d8832da43e2ac17d81b85c