### PR TITLE
Add pagination to user client assignments

### DIFF
--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -46,6 +46,7 @@
             </div>
             <input type="hidden" name="clientPage" value="1" />
             <input type="hidden" name="userPage" value="@Model.UserPage" />
+            <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
             <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
             <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
@@ -70,6 +71,7 @@
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
                             <input type="hidden" name="userPage" value="@Model.UserPage" />
+                            <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
                             <input type="hidden" name="selectedClientId" value="@client.ClientId" />
                             <input type="hidden" name="selectedClientRealm" value="@client.Realm" />
                             <input type="hidden" name="selectedClientName" value="@client.Name" />
@@ -92,6 +94,7 @@
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@(Model.ClientPage - 1)" />
                                     <input type="hidden" name="userPage" value="@Model.UserPage" />
+                                    <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
                                     <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
                                     <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
                                     <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
@@ -108,6 +111,7 @@
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@(Model.ClientPage + 1)" />
                                     <input type="hidden" name="userPage" value="@Model.UserPage" />
+                                    <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
                                     <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
                                     <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
                                     <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
@@ -154,6 +158,7 @@
             <input type="hidden" name="userPage" value="1" />
             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+            <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
             <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
             <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
             <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
@@ -177,6 +182,7 @@
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
                             <input type="hidden" name="userPage" value="@Model.UserPage" />
+                            <input type="hidden" name="assignmentPage" value="1" />
                             <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
                             <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
                             <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
@@ -199,6 +205,7 @@
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@Model.ClientPage" />
                                     <input type="hidden" name="userPage" value="@(Model.UserPage - 1)" />
+                                    <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
                                     <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
                                     <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
                                     <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
@@ -215,6 +222,7 @@
                                     <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                                     <input type="hidden" name="clientPage" value="@Model.ClientPage" />
                                     <input type="hidden" name="userPage" value="@(Model.UserPage + 1)" />
+                                    <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
                                     <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
                                     <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
                                     <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
@@ -290,6 +298,7 @@
             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
             <input type="hidden" name="userPage" value="@Model.UserPage" />
+            <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
             <button type="submit" class="btn-primary">Назначить доступ</button>
         </form>
     </div>
@@ -306,7 +315,7 @@
         @if (Model.Assignments.Any())
         {
             <div class="space-y-3">
-                @foreach (var client in Model.Assignments.OrderBy(c => c.Realm).ThenBy(c => c.ClientId))
+                @foreach (var client in Model.AssignmentPageItems)
                 {
                     <div class="flex items-center justify-between gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-3">
                         <div>
@@ -322,11 +331,54 @@
                             <input type="hidden" name="userQuery" value="@Model.UserQuery" />
                             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
                             <input type="hidden" name="userPage" value="@Model.UserPage" />
+                            <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
                             <button type="submit" class="btn-danger whitespace-nowrap">Удалить</button>
                         </form>
                     </div>
                 }
             </div>
+
+            @if (Model.AssignmentHasPreviousPage || Model.AssignmentHasNextPage)
+            {
+                <div class="flex items-center justify-between pt-2 text-sm text-slate-400">
+                    <div>Страница @Model.AssignmentPage из @Model.AssignmentTotalPages</div>
+                    <div class="flex items-center gap-2">
+                        @if (Model.AssignmentHasPreviousPage)
+                        {
+                            <form method="get" class="inline-flex">
+                                <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                                <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                                <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                                <input type="hidden" name="userPage" value="@Model.UserPage" />
+                                <input type="hidden" name="assignmentPage" value="@(Model.AssignmentPage - 1)" />
+                                <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
+                                <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
+                                <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
+                                <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
+                                <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                                <button type="submit" class="btn-subtle whitespace-nowrap">← Назад</button>
+                            </form>
+                        }
+
+                        @if (Model.AssignmentHasNextPage)
+                        {
+                            <form method="get" class="inline-flex">
+                                <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />
+                                <input type="hidden" name="userQuery" value="@Model.UserQuery" />
+                                <input type="hidden" name="clientPage" value="@Model.ClientPage" />
+                                <input type="hidden" name="userPage" value="@Model.UserPage" />
+                                <input type="hidden" name="assignmentPage" value="@(Model.AssignmentPage + 1)" />
+                                <input type="hidden" name="selectedClientId" value="@Model.SelectedClientId" />
+                                <input type="hidden" name="selectedClientRealm" value="@Model.SelectedClientRealm" />
+                                <input type="hidden" name="selectedClientName" value="@Model.SelectedClientName" />
+                                <input type="hidden" name="selectedUsername" value="@Model.SelectedUsername" />
+                                <input type="hidden" name="selectedUserDisplay" value="@Model.SelectedUserDisplay" />
+                                <button type="submit" class="btn-subtle whitespace-nowrap">Вперёд →</button>
+                            </form>
+                        }
+                    </div>
+                </div>
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary
- paginate the list of user client assignments on the Admin/UserClients page, showing five records per page with navigation controls
- preserve the current assignment page across client/user searches and updates while keeping redirects aware of the selected page

## Testing
- ⚠️ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5658e04c832d918e5e810132ef2e