### PR TITLE
Add create client shortcut to search page

### DIFF
--- a/Pages/Clients/Search.cshtml
+++ b/Pages/Clients/Search.cshtml
@@ -22,17 +22,22 @@
             </p>
         </div>
 
-        <form method="get" class="flex items-center gap-3 w-full md:w-auto">
-            <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[320px] focus-within:border-white/20">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <circle cx="11" cy="11" r="8" />
-                    <path d="m21 21-4.3-4.3" />
-                </svg>
-                <input name="q" value="@Model.Q" placeholder="Search all realms..."
-                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-            </div>
-            <button type="submit" class="btn-primary whitespace-nowrap">Найти</button>
-        </form>
+        <div class="flex items-center gap-3 w-full md:w-auto">
+            <form method="get" class="flex items-center gap-3 w-full md:w-auto">
+                <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[320px] focus-within:border-white/20">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8" />
+                        <path d="m21 21-4.3-4.3" />
+                    </svg>
+                    <input name="q" value="@Model.Q" placeholder="Search all realms..."
+                           class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
+                </div>
+                <button type="submit" class="btn-primary whitespace-nowrap">Найти</button>
+            </form>
+            <a asp-page="/Clients/Create" class="btn-primary whitespace-nowrap">
+                Создать клиента
+            </a>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- wrap the search form toolbar on the admin search page with a flex container
- add a "Создать клиента" button next to the existing search button to mirror the non-admin layout

## Testing
- attempted to run `dotnet build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68cf60fa21f8832db8d7887671c9c429