### PR TITLE
Add no-access page and enforce assistant role requirements

### DIFF
--- a/Pages/NoAccess.cshtml
+++ b/Pages/NoAccess.cshtml
@@ -1,0 +1,22 @@
+@page
+@model Assistant.Pages.NoAccessModel
+@{
+    ViewData["Title"] = "Нет доступа";
+}
+
+<section class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-8 text-center">
+            <h1 class="display-5 mb-4">Нет доступа</h1>
+            <p class="lead">У вас нет прав пользоваться этим веб-сервисом.</p>
+            @if (!string.IsNullOrWhiteSpace(Model.SupportEmail))
+            {
+                <p>Если вы считаете, что это ошибка, пожалуйста, напишите на <a href="mailto:@Model.SupportEmail">@Model.SupportEmail</a>.</p>
+            }
+            else
+            {
+                <p>Если вы считаете, что это ошибка, пожалуйста, обратитесь к администратору.</p>
+            }
+        </div>
+    </div>
+</section>

--- a/Pages/NoAccess.cshtml.cs
+++ b/Pages/NoAccess.cshtml.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+
+namespace Assistant.Pages;
+
+[AllowAnonymous]
+public class NoAccessModel : PageModel
+{
+    private readonly IConfiguration _configuration;
+
+    public NoAccessModel(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public string? SupportEmail { get; private set; }
+
+    public void OnGet()
+    {
+        SupportEmail = _configuration["App:SupportEmail"];
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 using Assistant.Interfaces;
 using Assistant.Services;
 using Assistant.KeyCloak;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -48,7 +49,13 @@ builder.Services.AddHttpClient("confluence-wiki", client =>
     client.Timeout = TimeSpan.FromSeconds(100);
 });
 builder.Services.AddSingleton<ConfluenceWikiService>();
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+    options.FallbackPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .RequireRole("assistant-admin", "assistant-user")
+        .Build();
+});
 
 builder.Services.Configure<ForwardedHeadersOptions>(opt =>
 {
@@ -64,6 +71,7 @@ builder.Services.AddAuthentication(options =>
 {
     options.Cookie.Name = ".KeycloakShell.Auth";
     options.SlidingExpiration = true;
+    options.AccessDeniedPath = "/NoAccess";
 })
 .AddOpenIdConnect(options =>
 {

--- a/appsettings.json
+++ b/appsettings.json
@@ -25,7 +25,8 @@
     "ConnectionWiki": "BaseUrl=http://localhost:8090/;User=admin;Password=admin;SpaceKey=DOM;ParentId=131148"
   },
   "App": {
-    "BaseUrl": "http://localhost:5000" // для post-logout редиректа. В DEV можно http://localhost:5000
+    "BaseUrl": "http://localhost:5000", // для post-logout редиректа. В DEV можно http://localhost:5000
+    "SupportEmail": "support@example.com"
   }
 
 }


### PR DESCRIPTION
## Summary
- enforce a fallback authorization policy that requires membership in assistant-admin or assistant-user roles
- redirect unauthorized users to a dedicated "no access" page and surface support email guidance
- expose the support contact email through configuration for display on the access denial page

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cfff3e3ef4832dacbe7a9d67408cf8