### PR TITLE
Restyle access denied page

### DIFF
--- a/Pages/AccessDenied.cshtml
+++ b/Pages/AccessDenied.cshtml
@@ -4,30 +4,53 @@
     ViewData["Title"] = "Недостаточно прав";
 }
 
-<section class="max-w-2xl mx-auto mt-16 bg-white/70 backdrop-blur rounded-xl shadow p-10 text-slate-800">
-    <h1 class="text-3xl font-semibold text-slate-900 mb-4">Недостаточно прав</h1>
-    <p class="mb-4 leading-relaxed">
-        К сожалению, у вашей учётной записи нет необходимого доступа для работы с сервисом.
-        Для продолжения требуется хотя бы одна из ролей:
-    </p>
-    <ul class="list-disc list-inside space-y-1 mb-6 text-sm text-slate-700">
-        @foreach (var role in Model.RequiredRoles)
-        {
-            <li><code class="px-2 py-0.5 rounded bg-slate-100 text-slate-900">@role</code></li>
-        }
-    </ul>
-    <p class="mb-6 text-sm text-slate-600">
-        Обратитесь к администратору, чтобы запросить доступ. После назначения роли обновите страницу или выполните повторный вход.
-    </p>
-    <div class="flex flex-wrap gap-3">
+<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-6">
+    <div class="absolute inset-0 pointer-events-none">
+        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
+             style="background: radial-gradient(60% 60% at 50% 50%, rgba(16,185,129,.6), rgba(59,130,246,.4))"></div>
+        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
+             style="background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35))"></div>
+    </div>
+
+    <div class="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+            <h1 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]">
+                Недостаточно прав
+            </h1>
+            <p class="text-slate-200/80 mt-2 text-sm max-w-2xl">
+                У вашей учётной записи нет необходимого доступа для работы с сервисом. Получите одну из требуемых ролей или войдите под другой учётной записью.
+            </p>
+        </div>
+    </div>
+</div>
+
+<section class="max-w-3xl mx-auto space-y-5">
+    <div class="kc-card p-6 space-y-4 text-slate-200/90">
+        <p class="leading-relaxed">
+            Для продолжения требуется хотя бы одна из следующих ролей:
+        </p>
+        <ul class="list-disc list-inside space-y-1 text-sm text-slate-300/90">
+            @foreach (var role in Model.RequiredRoles)
+            {
+                <li><code class="px-2 py-0.5 rounded bg-slate-900/50 text-slate-100">@role</code></li>
+            }
+        </ul>
+        <p class="text-sm text-slate-300/90">
+            Для получения доступа обратитесь по почте
+            <a href="mailto:breams@mail.ru" class="text-sky-300 hover:text-sky-200 underline decoration-dotted">
+                breams@mail.ru
+            </a>.
+        </p>
+    </div>
+
+    <div class="kc-card p-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-slate-200/90">
+        <div class="text-sm text-slate-300/90">
+            Если у вас есть учётная запись с необходимыми правами, выполните вход под ней.
+        </div>
         <form method="post" asp-page="/Account/Logout">
-            <button type="submit" class="px-5 py-2 rounded-md bg-slate-900 text-white hover:bg-slate-700 transition">
+            <button type="submit" class="btn-primary whitespace-nowrap">
                 Выйти и войти под другой учётной записью
             </button>
         </form>
-        <a class="px-5 py-2 rounded-md border border-slate-300 text-slate-700 hover:border-slate-400 transition"
-           href="/Account/GoToKeycloak?returnUrl=/">
-            Перейти к форме входа
-        </a>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- restyle the access denied page to reuse the shared header and kc-card styling
- remove the redundant sign-in form link and add an email contact for access requests

## Testing
- `dotnet build` *(fails: command not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d02342c1cc832dbab3ce2e7b65059f