### PR TITLE
Simplify access denied page request flow

### DIFF
--- a/Pages/AccessDenied.cshtml
+++ b/Pages/AccessDenied.cshtml
@@ -4,30 +4,88 @@
     ViewData["Title"] = "Недостаточно прав";
 }
 
-<section class="max-w-2xl mx-auto mt-16 bg-white/70 backdrop-blur rounded-xl shadow p-10 text-slate-800">
-    <h1 class="text-3xl font-semibold text-slate-900 mb-4">Недостаточно прав</h1>
-    <p class="mb-4 leading-relaxed">
-        К сожалению, у вашей учётной записи нет необходимого доступа для работы с сервисом.
-        Для продолжения требуется хотя бы одна из ролей:
-    </p>
-    <ul class="list-disc list-inside space-y-1 mb-6 text-sm text-slate-700">
-        @foreach (var role in Model.RequiredRoles)
-        {
-            <li><code class="px-2 py-0.5 rounded bg-slate-100 text-slate-900">@role</code></li>
-        }
-    </ul>
-    <p class="mb-6 text-sm text-slate-600">
-        Обратитесь к администратору, чтобы запросить доступ. После назначения роли обновите страницу или выполните повторный вход.
-    </p>
-    <div class="flex flex-wrap gap-3">
-        <form method="post" asp-page="/Account/Logout">
-            <button type="submit" class="px-5 py-2 rounded-md bg-slate-900 text-white hover:bg-slate-700 transition">
-                Выйти и войти под другой учётной записью
-            </button>
+<section class="max-w-2xl mx-auto py-10 space-y-8 text-slate-100">
+    <header class="space-y-3">
+        <h1 class="text-3xl font-semibold">Недостаточно прав</h1>
+        <p class="text-sm text-slate-300">
+            У вашей учётной записи нет необходимого доступа для работы с сервисом. Получите одну из требуемых ролей или
+            войдите под другой учётной записью.
+        </p>
+    </header>
+
+    <section class="rounded-xl border border-slate-800 bg-slate-950/60 p-6 space-y-4">
+        <p class="text-sm text-slate-200">
+            Для продолжения требуется хотя бы одна из следующих ролей:
+        </p>
+        <ul class="list-disc list-inside space-y-1 text-sm text-slate-300">
+            @foreach (var role in Model.RequiredRoles)
+            {
+                <li>@role</li>
+            }
+        </ul>
+        <p class="text-sm text-slate-300">
+            Если у вас есть учётная запись с необходимыми правами, выполните вход под ней или запросите доступ ниже.
+        </p>
+    </section>
+
+    <section class="rounded-xl border border-slate-800 bg-slate-950/60 p-6 space-y-4">
+        <h2 class="text-lg font-medium text-slate-100">Запросить доступ</h2>
+        <p class="text-sm text-slate-300">
+            Заполните форму, и мы подготовим письмо с просьбой о предоставлении доступа.
+        </p>
+        <form id="access-request-form" class="space-y-4">
+            <div class="space-y-2">
+                <label for="access-request-fullname" class="block text-sm text-slate-200">ФИО</label>
+                <input id="access-request-fullname" name="fullName" type="text" required
+                       class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/30"
+                       placeholder="Иванов Иван Иванович">
+            </div>
+            <div class="text-xs text-slate-400">
+                Нажатие на кнопку откроет ваш почтовый клиент с готовым письмом на адрес
+                <a href="mailto:breams@mail.ru" class="text-sky-300 hover:text-sky-200">breams@mail.ru</a>.
+            </div>
+            <button type="submit" class="btn-primary">Отправить заявку</button>
         </form>
-        <a class="px-5 py-2 rounded-md border border-slate-300 text-slate-700 hover:border-slate-400 transition"
-           href="/Account/GoToKeycloak?returnUrl=/">
-            Перейти к форме входа
-        </a>
-    </div>
+    </section>
+
+    <section class="rounded-xl border border-slate-800 bg-slate-950/60 p-6 space-y-4">
+        <h2 class="text-lg font-medium text-slate-100">Войти под другой учётной записью</h2>
+        <p class="text-sm text-slate-300">
+            Если у вас есть другой аккаунт с нужными правами, выйдите и войдите под ним.
+        </p>
+        <form method="post" asp-page="/Account/Logout">
+            <button type="submit" class="btn-secondary">Выйти и сменить аккаунт</button>
+        </form>
+    </section>
 </section>
+
+<script>
+    (() => {
+        const form = document.getElementById('access-request-form');
+        if (!form) {
+            return;
+        }
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+
+            const fullNameInput = document.getElementById('access-request-fullname');
+            if (!(fullNameInput instanceof HTMLInputElement)) {
+                return;
+            }
+
+            const fullName = fullNameInput.value.trim();
+            if (!fullName) {
+                fullNameInput.focus();
+                fullNameInput.reportValidity();
+                return;
+            }
+
+            const recipient = 'breams@mail.ru';
+            const subject = encodeURIComponent('Заявка на доступ к Assistant');
+            const body = encodeURIComponent(`Прошу дать доступ к Assistant\n${fullName}`);
+
+            window.location.href = `mailto:${recipient}?subject=${subject}&body=${body}`;
+        });
+    })();
+</script>


### PR DESCRIPTION
## Summary
- replace the AccessDenied page's decorative layout with a simple stacked layout
- add a short access request form that opens a prefilled email to breams@mail.ru with the user's ФИО
- clarify the logout option for switching to an account that already has the required roles

## Testing
- `dotnet build` *(fails: command not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d02342c1cc832dbab3ce2e7b65059f