### PR TITLE
Add backend-driven access request email submission

### DIFF
--- a/Models/AccessRequestPayload.cs
+++ b/Models/AccessRequestPayload.cs
@@ -1,0 +1,3 @@
+namespace Assistant.Models;
+
+public sealed record AccessRequestPayload(string FullName);

--- a/Pages/AccessDenied.cshtml
+++ b/Pages/AccessDenied.cshtml
@@ -80,23 +80,33 @@
                             <article class="rounded-2xl border border-slate-800/70 bg-gradient-to-br from-slate-900/70 via-slate-950/80 to-slate-950/50 p-6 shadow-inner shadow-slate-950/40">
                                 <h2 class="text-base font-medium text-slate-100">Запросить доступ</h2>
                                 <p class="mt-2 text-sm text-slate-300">
-                                    Заполните ваши данные — мы сформируем письмо в отдел поддержки.
+                                    Заполните ваши данные — мы отправим заявку в отдел поддержки.
                                 </p>
-                                <form id="access-request-form" class="mt-5 space-y-4">
+                                <form id="access-request-form" class="mt-5 space-y-4" data-support-email="@Model.SupportEmail">
                                     <div class="space-y-2">
                                         <label for="access-request-fullname" class="block text-xs font-semibold uppercase tracking-wide text-slate-400">ФИО</label>
                                         <input id="access-request-fullname" name="fullName" type="text" required
                                                class="w-full rounded-xl border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/30"
                                                placeholder="Иванов Иван Иванович">
                                     </div>
-                                    <p class="text-xs text-slate-400">
-                                        После отправки откроется ваш почтовый клиент с готовым письмом на адрес
-                                        <a href="mailto:breams@mail.ru" class="font-medium text-sky-300 hover:text-sky-200">breams@mail.ru</a>.
-                                    </p>
+                                    @if (!string.IsNullOrWhiteSpace(Model.SupportEmail))
+                                    {
+                                        <p class="text-xs text-slate-400">
+                                            Письмо будет отправлено на адрес
+                                            <span class="font-medium text-sky-300">@Model.SupportEmail</span>.
+                                        </p>
+                                    }
+                                    else
+                                    {
+                                        <p class="text-xs text-slate-400">
+                                            Письмо будет отправлено в службу поддержки.
+                                        </p>
+                                    }
                                     <button type="submit"
                                             class="inline-flex items-center justify-center rounded-xl border border-sky-500/40 bg-sky-500/20 px-4 py-2 text-sm font-medium text-sky-100 transition hover:border-sky-400/60 hover:bg-sky-500/30">
                                         Отправить заявку
                                     </button>
+                                    <p id="access-request-status" class="text-xs text-slate-400" aria-live="polite"></p>
                                 </form>
                             </article>
                         </div>
@@ -128,7 +138,29 @@
                 return;
             }
 
-            form.addEventListener('submit', (event) => {
+            const statusNode = document.getElementById('access-request-status');
+            const submitButton = form.querySelector('button[type="submit"]');
+            const defaultButtonText = submitButton?.textContent ?? '';
+
+            const setStatus = (message, type = 'info') => {
+                if (!statusNode) {
+                    return;
+                }
+
+                const baseClasses = ['text-xs'];
+                if (type === 'success') {
+                    baseClasses.push('text-emerald-400');
+                } else if (type === 'error') {
+                    baseClasses.push('text-rose-400');
+                } else {
+                    baseClasses.push('text-slate-400');
+                }
+
+                statusNode.className = baseClasses.join(' ');
+                statusNode.textContent = message;
+            };
+
+            form.addEventListener('submit', async (event) => {
                 event.preventDefault();
 
                 const fullNameInput = document.getElementById('access-request-fullname');
@@ -143,11 +175,52 @@
                     return;
                 }
 
-                const recipient = 'breams@mail.ru';
-                const subject = encodeURIComponent('Заявка на доступ к Assistant');
-                const body = encodeURIComponent(`Прошу дать доступ к Assistant\n${fullName}`);
+                setStatus('Отправляем заявку...', 'info');
 
-                window.location.href = `mailto:${recipient}?subject=${subject}&body=${body}`;
+                if (submitButton) {
+                    submitButton.disabled = true;
+                    submitButton.textContent = 'Отправляем...';
+                    submitButton.classList.add('opacity-70', 'cursor-not-allowed');
+                }
+
+                try {
+                    const response = await fetch('/api/access-request', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({ fullName })
+                    });
+
+                    if (!response.ok) {
+                        let message = 'Не удалось отправить заявку. Попробуйте позже.';
+                        try {
+                            const data = await response.json();
+                            if (typeof data?.error === 'string' && data.error.trim()) {
+                                message = data.error.trim();
+                            } else if (typeof data?.title === 'string' && data.title.trim()) {
+                                message = data.title.trim();
+                            }
+                        } catch (error) {
+                            console.error('Failed to parse error response', error);
+                        }
+
+                        throw new Error(message);
+                    }
+
+                    form.reset();
+                    setStatus('Заявка отправлена. Мы свяжемся с вами после обработки.', 'success');
+                } catch (error) {
+                    console.error('Failed to send access request', error);
+                    const message = error instanceof Error ? error.message : 'Не удалось отправить заявку. Попробуйте позже.';
+                    setStatus(message, 'error');
+                } finally {
+                    if (submitButton) {
+                        submitButton.disabled = false;
+                        submitButton.textContent = defaultButtonText || 'Отправить заявку';
+                        submitButton.classList.remove('opacity-70', 'cursor-not-allowed');
+                    }
+                }
             });
         })();
     </script>

--- a/Pages/AccessDenied.cshtml.cs
+++ b/Pages/AccessDenied.cshtml.cs
@@ -1,5 +1,7 @@
+using Assistant.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
 
 namespace Assistant.Pages;
 
@@ -11,4 +13,11 @@ public class AccessDeniedModel : PageModel
         "assistant-user",
         "assistant-admin"
     };
+
+    public string? SupportEmail { get; }
+
+    public AccessDeniedModel(IOptions<EmailOptions> options)
+    {
+        SupportEmail = options.Value.SupportRecipient;
+    }
 }

--- a/Services/AccessRequestEmailSender.cs
+++ b/Services/AccessRequestEmailSender.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Mail;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Assistant.Services;
+
+public interface IAccessRequestEmailSender
+{
+    Task SendAsync(string fullName, CancellationToken cancellationToken = default);
+}
+
+public sealed class AccessRequestEmailSender : IAccessRequestEmailSender
+{
+    private readonly EmailOptions _options;
+    private readonly ILogger<AccessRequestEmailSender> _logger;
+
+    public AccessRequestEmailSender(IOptions<EmailOptions> options, ILogger<AccessRequestEmailSender> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SendAsync(string fullName, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullName);
+
+        var host = _options.Host;
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            throw new InvalidOperationException("SMTP host is not configured.");
+        }
+
+        var recipient = _options.SupportRecipient;
+        if (string.IsNullOrWhiteSpace(recipient))
+        {
+            throw new InvalidOperationException("Support recipient email is not configured.");
+        }
+
+        var fromAddress = _options.From;
+        if (string.IsNullOrWhiteSpace(fromAddress))
+        {
+            fromAddress = _options.Username;
+            if (string.IsNullOrWhiteSpace(fromAddress))
+            {
+                throw new InvalidOperationException("Sender email is not configured.");
+            }
+        }
+
+        using var message = new MailMessage
+        {
+            From = new MailAddress(fromAddress),
+            Subject = "Заявка на доступ к Assistant",
+            Body = $"Прошу дать доступ к Assistant{Environment.NewLine}{fullName.Trim()}.",
+            SubjectEncoding = Encoding.UTF8,
+            BodyEncoding = Encoding.UTF8
+        };
+
+        message.To.Add(new MailAddress(recipient));
+
+        using var client = new SmtpClient(host, _options.Port)
+        {
+            EnableSsl = _options.EnableSsl
+        };
+
+        if (!string.IsNullOrWhiteSpace(_options.Username))
+        {
+            client.Credentials = new NetworkCredential(_options.Username, _options.Password);
+        }
+
+        try
+        {
+            await client.SendMailAsync(message, cancellationToken);
+            _logger.LogInformation("Sent access request email for {FullName}.", fullName);
+        }
+        catch (Exception ex) when (ex is SmtpException or InvalidOperationException or FormatException)
+        {
+            _logger.LogError(ex, "Failed to send access request email for {FullName}.", fullName);
+            throw;
+        }
+    }
+}

--- a/Services/EmailOptions.cs
+++ b/Services/EmailOptions.cs
@@ -1,0 +1,18 @@
+namespace Assistant.Services;
+
+public sealed class EmailOptions
+{
+    public string? From { get; set; }
+
+    public string? SupportRecipient { get; set; }
+
+    public string? Host { get; set; }
+
+    public int Port { get; set; } = 25;
+
+    public bool EnableSsl { get; set; } = true;
+
+    public string? Username { get; set; }
+
+    public string? Password { get; set; }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -26,6 +26,15 @@
   },
   "App": {
     "BaseUrl": "http://localhost:5000" // для post-logout редиректа. В DEV можно http://localhost:5000
+  },
+  "Email": {
+    "From": "no-reply@example.com",
+    "SupportRecipient": "breams@mail.ru",
+    "Host": "smtp.example.com",
+    "Port": 587,
+    "EnableSsl": true,
+    "Username": "smtp-user",
+    "Password": "smtp-password"
   }
 
 }

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -21,10 +21,9 @@
 
 /* Background */
 .bg-dark-pattern {
-    background-color: var(--kc-bg);
-    background-image: radial-gradient(rgba(255,255,255,0.03) 1px, transparent 1px), radial-gradient(rgba(255,255,255,0.02) 1px, transparent 1px), radial-gradient(700px 420px at 12% -10%, rgba(99,102,241,0.08), transparent 60%), radial-gradient(900px 520px at 100% 110%, rgba(45,212,191,0.06), transparent 65%);
-    background-size: 18px 18px, 32px 32px, auto, auto;
-    background-position: 0 0, 8px 10px, center, center;
+    background-color: #06080f;
+    background-image: linear-gradient(140deg, rgba(15,23,42,0.65), rgba(2,6,23,0.9));
+    background-attachment: fixed;
 }
 
 /* ===== Glass Header ===== */


### PR DESCRIPTION
## Summary
- replace the existing patterned layout background with a minimal dark gradient
- add configurable SMTP email sender services and options for access requests
- update the access denied form to call a backend API that sends the email and shows submission status

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d02e5fa5a8832d929281864cd59f9c