### PR TITLE
Update access request email to use user login

### DIFF
--- a/Models/AccessRequestPayload.cs
+++ b/Models/AccessRequestPayload.cs
@@ -1,3 +1,0 @@
-namespace Assistant.Models;
-
-public sealed record AccessRequestPayload(string FullName, string Email);

--- a/Pages/AccessDenied.cshtml
+++ b/Pages/AccessDenied.cshtml
@@ -81,34 +81,29 @@
                             <article class="rounded-2xl border border-slate-700/60 bg-gradient-to-br from-slate-900/70 via-slate-900/55 to-slate-950/80 p-6 shadow-inner shadow-slate-950/30">
                                 <h2 class="text-base font-medium text-slate-100">Запросить доступ</h2>
                                 <p class="mt-2 text-sm text-slate-300">
-                                    Заполните ваши данные — мы отправим заявку в отдел поддержки.
+                                    Нажмите кнопку — мы отправим заявку в отдел поддержки с вашим логином.
                                 </p>
-                                <form id="access-request-form" class="mt-5 space-y-4" data-support-email="@Model.SupportEmail">
-                                    <div class="space-y-2">
-                                        <label for="access-request-fullname" class="block text-xs font-semibold uppercase tracking-wide text-slate-400">ФИО</label>
-                                        <input id="access-request-fullname" name="fullName" type="text" required
-                                               class="w-full rounded-xl border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/30"
-                                               placeholder="Иванов Иван Иванович">
-                                    </div>
-                                    <div class="space-y-2">
-                                        <label for="access-request-email" class="block text-xs font-semibold uppercase tracking-wide text-slate-400">Ваш email</label>
-                                        <input id="access-request-email" name="email" type="email" required autocomplete="email"
-                                               class="w-full rounded-xl border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/30"
-                                               placeholder="you@example.com">
-                                    </div>
-                                    @if (!string.IsNullOrWhiteSpace(Model.SupportEmail))
-                                    {
-                                        <p class="text-xs text-slate-400">
-                                            Письмо будет отправлено на адрес
-                                            <span class="font-medium text-sky-300">@Model.SupportEmail</span>.
-                                        </p>
-                                    }
-                                    else
-                                    {
-                                        <p class="text-xs text-slate-400">
-                                            Письмо будет отправлено в службу поддержки.
-                                        </p>
-                                    }
+                                @if (!string.IsNullOrWhiteSpace(Model.UserLogin))
+                                {
+                                    <p class="mt-3 text-sm text-slate-300">
+                                        Заявка будет отправлена для пользователя
+                                        <span class="font-medium text-sky-300">@Model.UserLogin</span>.
+                                    </p>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(Model.SupportEmail))
+                                {
+                                    <p class="mt-3 text-xs text-slate-400">
+                                        Письмо будет отправлено на адрес
+                                        <span class="font-medium text-sky-300">@Model.SupportEmail</span>.
+                                    </p>
+                                }
+                                else
+                                {
+                                    <p class="mt-3 text-xs text-slate-400">
+                                        Письмо будет отправлено в службу поддержки.
+                                    </p>
+                                }
+                                <form id="access-request-form" class="mt-5 space-y-4">
                                     <button type="submit"
                                             class="inline-flex items-center justify-center rounded-xl border border-sky-400/60 bg-sky-500/25 px-4 py-2 text-sm font-medium text-sky-100 transition hover:border-sky-300/70 hover:bg-sky-500/35">
                                         Отправить заявку
@@ -170,32 +165,6 @@
             form.addEventListener('submit', async (event) => {
                 event.preventDefault();
 
-                const fullNameInput = document.getElementById('access-request-fullname');
-                const emailInput = document.getElementById('access-request-email');
-                if (!(fullNameInput instanceof HTMLInputElement) || !(emailInput instanceof HTMLInputElement)) {
-                    return;
-                }
-
-                const fullName = fullNameInput.value.trim();
-                if (!fullName) {
-                    fullNameInput.focus();
-                    fullNameInput.reportValidity();
-                    return;
-                }
-
-                const email = emailInput.value.trim();
-                if (!email) {
-                    emailInput.focus();
-                    emailInput.reportValidity();
-                    return;
-                }
-
-                if (!emailInput.checkValidity()) {
-                    emailInput.focus();
-                    emailInput.reportValidity();
-                    return;
-                }
-
                 setStatus('Отправляем заявку...', 'info');
 
                 if (submitButton) {
@@ -206,11 +175,7 @@
 
                 try {
                     const response = await fetch('/api/access-request', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify({ fullName, email })
+                        method: 'POST'
                     });
 
                     if (!response.ok) {
@@ -229,7 +194,6 @@
                         throw new Error(message);
                     }
 
-                    form.reset();
                     setStatus('Заявка отправлена. Мы свяжемся с вами после обработки.', 'success');
                 } catch (error) {
                     console.error('Failed to send access request', error);

--- a/Pages/AccessDenied.cshtml.cs
+++ b/Pages/AccessDenied.cshtml.cs
@@ -2,6 +2,7 @@ using Assistant.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
+using System.Security.Claims;
 
 namespace Assistant.Pages;
 
@@ -15,9 +16,20 @@ public class AccessDeniedModel : PageModel
     };
 
     public string? SupportEmail { get; }
+    public string? UserLogin { get; private set; }
 
     public AccessDeniedModel(IOptions<EmailOptions> options)
     {
         SupportEmail = options.Value.SupportRecipient;
+    }
+
+    public void OnGet()
+    {
+        var user = User ?? HttpContext.User;
+
+        UserLogin = user?.Identity?.Name
+            ?? user?.FindFirst("preferred_username")?.Value
+            ?? user?.FindFirst(ClaimTypes.Name)?.Value
+            ?? user?.FindFirst(ClaimTypes.Email)?.Value;
     }
 }

--- a/Services/AccessRequestEmailSender.cs
+++ b/Services/AccessRequestEmailSender.cs
@@ -8,7 +8,7 @@ namespace Assistant.Services;
 
 public interface IAccessRequestEmailSender
 {
-    Task SendAsync(string fullName, string email, CancellationToken cancellationToken = default);
+    Task SendAsync(string login, CancellationToken cancellationToken = default);
 }
 
 public sealed class AccessRequestEmailSender : IAccessRequestEmailSender
@@ -22,10 +22,9 @@ public sealed class AccessRequestEmailSender : IAccessRequestEmailSender
         _logger = logger;
     }
 
-    public async Task SendAsync(string fullName, string email, CancellationToken cancellationToken = default)
+    public async Task SendAsync(string login, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(fullName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        ArgumentException.ThrowIfNullOrWhiteSpace(login);
 
         var host = _options.Host;
         if (string.IsNullOrWhiteSpace(host))
@@ -49,14 +48,13 @@ public sealed class AccessRequestEmailSender : IAccessRequestEmailSender
             }
         }
 
-        var trimmedFullName = fullName.Trim();
-        var trimmedEmail = email.Trim();
+        var trimmedLogin = login.Trim();
 
         using var message = new MailMessage
         {
             From = new MailAddress(fromAddress),
             Subject = "Заявка на доступ к Assistant",
-            Body = $"Прошу дать доступ к Assistant{Environment.NewLine}{trimmedFullName}.{Environment.NewLine}{Environment.NewLine}Email: {trimmedEmail}",
+            Body = $"Прошу предоставить доступ в Assistant.{Environment.NewLine}Логин: {trimmedLogin}",
             SubjectEncoding = Encoding.UTF8,
             BodyEncoding = Encoding.UTF8
         };
@@ -76,11 +74,11 @@ public sealed class AccessRequestEmailSender : IAccessRequestEmailSender
         try
         {
             await client.SendMailAsync(message, cancellationToken);
-            _logger.LogInformation("Sent access request email for {FullName} ({Email}).", trimmedFullName, trimmedEmail);
+            _logger.LogInformation("Sent access request email for {Login}.", trimmedLogin);
         }
         catch (Exception ex) when (ex is SmtpException or InvalidOperationException or FormatException)
         {
-            _logger.LogError(ex, "Failed to send access request email for {FullName} ({Email}).", trimmedFullName, trimmedEmail);
+            _logger.LogError(ex, "Failed to send access request email for {Login}.", trimmedLogin);
             throw;
         }
     }


### PR DESCRIPTION
## Summary
- update the access request page to show the current login and send the request without collecting name or email
- derive the user login on the server and send streamlined support emails
- remove the obsolete access request payload record

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d111578f78832d982ff79a5b58226e