### PR TITLE
Normalize audit log operation types

### DIFF
--- a/Pages/Admin/Events.cshtml.cs
+++ b/Pages/Admin/Events.cshtml.cs
@@ -135,12 +135,6 @@ public sealed class EventsModel : PageModel
             return string.Empty;
         }
 
-        var colonIndex = value.IndexOf(':');
-        if (colonIndex < 0 || colonIndex + 1 >= value.Length)
-        {
-            return value;
-        }
-
-        return value[(colonIndex + 1)..].Trim();
+        return ApiLogRepository.NormalizeOperationType(value);
     }
 }


### PR DESCRIPTION
## Summary
- normalize audit log operation types before persisting and when querying so only the suffix (e.g. CREATE/DELETE) remains
- deduplicate and sort available audit operation types after normalization
- reuse the normalization helper when formatting operation types for the events page

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d141969810832d8e400fae9d04950d