### PR TITLE
Expand admin events table spacing

### DIFF
--- a/Pages/Admin/Events.cshtml
+++ b/Pages/Admin/Events.cshtml
@@ -73,29 +73,29 @@
     {
         <div class="kc-card p-0 overflow-hidden">
             <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-white/10 text-sm text-center">
-                    <thead class="bg-white/5 uppercase tracking-wide text-xs text-slate-300">
+                <table class="min-w-full divide-y divide-white/10 text-base leading-6 text-center">
+                    <thead class="bg-white/5 uppercase tracking-wide text-sm text-slate-300">
                         <tr>
-                            <th class="px-4 py-3 text-center">ID</th>
-                            <th class="px-4 py-3 text-center">Дата и время</th>
-                            <th class="px-4 py-3 text-center">Тип</th>
-                            <th class="px-4 py-3 text-center">Пользователь</th>
-                            <th class="px-4 py-3 text-center">Realm</th>
-                            <th class="px-4 py-3 text-center">Target ID</th>
-                            <th class="px-4 py-3 text-center">Details</th>
+                            <th class="px-5 py-4 text-center">ID</th>
+                            <th class="px-5 py-4 text-center">Дата и время</th>
+                            <th class="px-5 py-4 text-center">Тип</th>
+                            <th class="px-5 py-4 text-center">Пользователь</th>
+                            <th class="px-5 py-4 text-center">Realm</th>
+                            <th class="px-5 py-4 text-center">Target ID</th>
+                            <th class="px-5 py-4 text-center">Details</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-white/10">
                         @foreach (var log in Model.Logs)
                         {
                             <tr class="hover:bg-white/5 transition">
-                                <td class="px-4 py-3 whitespace-nowrap font-mono text-xs text-slate-300 text-center">@log.Id</td>
-                                <td class="px-4 py-3 whitespace-nowrap font-mono text-xs text-slate-200 text-center">@Model.FormatTimestamp(log.CreatedAtUtc)</td>
-                                <td class="px-4 py-3 whitespace-nowrap text-slate-100 text-center">@Model.FormatOperationType(log.OperationType)</td>
-                                <td class="px-4 py-3 whitespace-nowrap text-slate-100 text-center">@log.Username</td>
-                                <td class="px-4 py-3 whitespace-nowrap text-slate-100 text-center">@log.Realm</td>
-                                <td class="px-4 py-3 whitespace-nowrap text-slate-100 text-center">@log.TargetId</td>
-                                <td class="px-4 py-3 text-xs text-slate-100 whitespace-pre-wrap font-mono text-center">@(string.IsNullOrWhiteSpace(log.Details) ? "-" : log.Details)</td>
+                                <td class="px-5 py-4 whitespace-nowrap font-mono text-sm text-slate-300 text-center">@log.Id</td>
+                                <td class="px-5 py-4 whitespace-nowrap font-mono text-sm text-slate-200 text-center">@Model.FormatTimestamp(log.CreatedAtUtc)</td>
+                                <td class="px-5 py-4 whitespace-nowrap text-slate-100 text-center">@Model.FormatOperationType(log.OperationType)</td>
+                                <td class="px-5 py-4 whitespace-nowrap text-slate-100 text-center">@log.Username</td>
+                                <td class="px-5 py-4 whitespace-nowrap text-slate-100 text-center">@log.Realm</td>
+                                <td class="px-5 py-4 whitespace-nowrap text-slate-100 text-center">@log.TargetId</td>
+                                <td class="px-5 py-4 text-sm text-slate-100 whitespace-pre-wrap font-mono text-center">@(string.IsNullOrWhiteSpace(log.Details) ? "-" : log.Details)</td>
                             </tr>
                         }
                     </tbody>


### PR DESCRIPTION
## Summary
- enlarge the admin events table typography and padding to make rows easier to read

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d14fe4ef7c832d8ddeb38cd8978805