### PR TITLE
Refine events audit log display and messaging

### DIFF
--- a/Pages/Admin/Events.cshtml
+++ b/Pages/Admin/Events.cshtml
@@ -76,7 +76,6 @@
                 <table class="min-w-full divide-y divide-white/10 text-base leading-6 text-center">
                     <thead class="bg-white/5 uppercase tracking-wide text-sm text-slate-300">
                         <tr>
-                            <th class="px-5 py-4 text-center">ID</th>
                             <th class="px-5 py-4 text-center">Дата и время</th>
                             <th class="px-5 py-4 text-center">Тип</th>
                             <th class="px-5 py-4 text-center">Пользователь</th>
@@ -89,7 +88,6 @@
                         @foreach (var log in Model.Logs)
                         {
                             <tr class="hover:bg-white/5 transition">
-                                <td class="px-5 py-4 whitespace-nowrap font-mono text-sm text-slate-300 text-center">@log.Id</td>
                                 <td class="px-5 py-4 whitespace-nowrap font-mono text-sm text-slate-200 text-center">@Model.FormatTimestamp(log.CreatedAtUtc)</td>
                                 <td class="px-5 py-4 whitespace-nowrap text-slate-100 text-center">@Model.FormatOperationType(log.OperationType)</td>
                                 <td class="px-5 py-4 whitespace-nowrap text-slate-100 text-center">@log.Username</td>

--- a/Pages/Admin/UserClients.cshtml.cs
+++ b/Pages/Admin/UserClients.cshtml.cs
@@ -439,27 +439,23 @@ public sealed class UserClientsModel : PageModel
         var normalizedClientId = string.IsNullOrWhiteSpace(clientId) ? "-" : clientId;
         var normalizedTargetUser = string.IsNullOrWhiteSpace(targetUser) ? "-" : targetUser;
 
-        var detailsParts = new List<string>();
+        var clientDisplay = string.IsNullOrWhiteSpace(clientName)
+            ? $"{normalizedClientId} ({normalizedRealm})"
+            : $"{clientName} ({normalizedClientId}, {normalizedRealm})";
 
-        if (!string.IsNullOrWhiteSpace(clientName)
-            && !string.Equals(clientName, normalizedClientId, StringComparison.Ordinal))
+        var normalizedOperation = ApiLogRepository.NormalizeOperationType(operationType);
+        string details = normalizedOperation switch
         {
-            detailsParts.Add($"clientName={clientName}");
-        }
-
-        if (!string.IsNullOrWhiteSpace(targetDisplay)
-            && !string.Equals(targetDisplay, normalizedTargetUser, StringComparison.OrdinalIgnoreCase))
-        {
-            detailsParts.Add($"targetDisplay={targetDisplay}");
-        }
-
-        var details = detailsParts.Count == 0 ? null : string.Join("; ", detailsParts);
+            "GRANT" => $"Пользователю {normalizedTargetUser} присвоено: {clientDisplay}",
+            "REVOKE" => $"Пользователю {normalizedTargetUser} удалены клиенты: {clientDisplay}",
+            _ => $"Пользователю {normalizedTargetUser} обновлены клиенты: {clientDisplay}"
+        };
 
         return _logs.LogAsync(
             operationType,
             actor,
             normalizedRealm,
-            $"{normalizedClientId}:{normalizedTargetUser}",
+            normalizedTargetUser,
             details,
             ct);
     }


### PR DESCRIPTION
## Summary
- remove the numeric identifier column from the admin events table view
- tailor the audit log details text to say "присвоено" for grants and "удалены" for revocations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d151e6c840832d979447ddbeab2f08