### PR TITLE
Redesign clients dashboard to glassmorphism layout

### DIFF
--- a/Pages/Clients/Search.cshtml
+++ b/Pages/Clients/Search.cshtml
@@ -4,50 +4,38 @@
     ViewData["Title"] = "Поиск клиентов";
 }
 
-<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-5">
-    <div class="absolute inset-0 pointer-events-none">
-        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(16,185,129,.6), rgba(59,130,246,.4))"></div>
-        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35))"></div>
-    </div>
+<div class="clients-stage">
+    <div class="clients-surface">
+        <div class="clients-toolbar">
+            <div class="clients-heading">
+                <h3 class="clients-title">Поиск клиентов</h3>
+                <p class="clients-subtitle">Выполните поиск по всем реалмам Keycloak. Результаты фильтруются по введённому clientId.</p>
+            </div>
 
-    <div class="relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
-            <h3 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]">
-                Поиск клиентов
-            </h3>
-            <p class="text-slate-200/80 mt-2 text-sm max-w-xl">
-                Выполните поиск по всем реалмам Keycloak. Результаты отфильтруются по введённому clientId.
-            </p>
-        </div>
-
-        <div class="flex items-center gap-3 w-full md:w-auto">
-            <form method="get" class="flex items-center gap-3 w-full md:w-auto">
-                <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[320px] focus-within:border-white/20">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <div class="clients-actions">
+                <form method="get" class="clients-search clients-search--wide" aria-label="Поиск по всем реалмам">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="clients-search__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <circle cx="11" cy="11" r="8" />
                         <path d="m21 21-4.3-4.3" />
                     </svg>
-                    <input name="q" value="@Model.Q" placeholder="Search all realms..."
-                           class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-                </div>
-                <button type="submit" class="btn-primary whitespace-nowrap">Найти</button>
-            </form>
-            <a asp-page="/Clients/Create" class="btn-primary whitespace-nowrap">
-                Создать клиента
-            </a>
+                    <input name="q" value="@Model.Q" placeholder="Search all realms..." class="clients-search__input" />
+                    <button type="submit" class="clients-search__submit">Найти</button>
+                </form>
+                <a asp-page="/Clients/Create" class="btn-primary clients-create whitespace-nowrap">
+                    Создать клиента
+                </a>
+            </div>
+        </div>
+
+        @if (string.IsNullOrEmpty(Model.Q))
+        {
+            <div class="clients-info clients-info--muted">
+                Введите идентификатор клиента, чтобы получить результаты поиска по всем доступным реалмам.
+            </div>
+        }
+
+        <div id="clientsContainer">
+            @await Html.PartialAsync("_ClientsList", Model)
         </div>
     </div>
-</div>
-
-@if (string.IsNullOrEmpty(Model.Q))
-{
-    <div class="kc-card mb-5 p-5 text-sm text-slate-300/90">
-        Введите идентификатор клиента, чтобы получить результаты поиска по всем доступным реалмам.
-    </div>
-}
-
-<div id="clientsContainer">
-    @await Html.PartialAsync("_ClientsList", Model)
 </div>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -4,44 +4,40 @@
     ViewData["Title"] = "Clients";
 }
 
-<!-- Шапка как на Details/Index — стеклянная, с аурами -->
-<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-5">
-    <div class="absolute inset-0 pointer-events-none">
-        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(16,185,129,.6), rgba(59,130,246,.4))"></div>
-        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35))"></div>
-    </div>
-
-    <div class="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <h3 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]">
-            Мои клиенты
-        </h3>
-
-        <div class="flex items-center gap-3 w-full md:w-auto">
-            <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[260px] focus-within:border-white/20">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <circle cx="11" cy="11" r="8" />
-                    <path d="m21 21-4.3-4.3" />
-                </svg>
-                <input id="clientFilter" placeholder="Search clients..."
-                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
+<div class="clients-stage">
+    <div class="clients-surface">
+        <div class="clients-toolbar">
+            <div class="clients-heading">
+                <h3 class="clients-title">Мои клиенты</h3>
+                <p class="clients-subtitle">Локальный список клиентов, к которым у вас есть доступ.</p>
             </div>
 
-            <a asp-page="/Clients/Create" class="btn-primary">
-                Создать клиента
-            </a>
+            <div class="clients-actions">
+                <label class="clients-search" aria-label="Фильтр по клиентам">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="clients-search__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8" />
+                        <path d="m21 21-4.3-4.3" />
+                    </svg>
+                    <input id="clientFilter" placeholder="Search clients..." class="clients-search__input" />
+                </label>
+
+                <a asp-page="/Clients/Create" class="btn-primary clients-create">
+                    Создать клиента
+                </a>
+            </div>
+        </div>
+
+        @if (User.IsInRole("assistant-admin"))
+        {
+            <div class="clients-info clients-info--muted">
+                Используйте пункт «Поиск клиентов» в панели слева, чтобы найти клиентов во всех реалмах.
+            </div>
+        }
+
+        <div id="clientsContainer">
+            @await Html.PartialAsync("_ClientsList", Model)
         </div>
     </div>
-</div>
-@if (User.IsInRole("assistant-admin"))
-{
-    <div class="kc-card mb-5 p-5 text-sm text-slate-300/90">
-        Используйте пункт «Поиск клиентов» в панели слева, чтобы найти клиентов во всех реалмах.
-    </div>
-}
-<div id="clientsContainer">
-    @await Html.PartialAsync("_ClientsList", Model)
 </div>
 
 <script data-soft-nav>

--- a/Pages/Shared/_ClientsList.cshtml
+++ b/Pages/Shared/_ClientsList.cshtml
@@ -9,18 +9,16 @@
 
 @if (!Model.Clients.Any() && Model.ShowEmptyMessage)
 {
-    <div class="kc-card p-10 text-center">
-        <div class="text-slate-200 text-lg font-semibold mb-1">Нет клиентов</div>
-        <div class="text-slate-400 text-sm">Попробуйте другой поиск или создайте нового клиента.</div>
+    <div class="clients-info clients-info--empty">
+        <div class="clients-info__title">Нет клиентов</div>
+        <div class="clients-info__subtitle">Попробуйте другой поиск или создайте нового клиента.</div>
     </div>
 }
 else if (Model.Clients.Any())
 {
-    <!-- Сетка карточек клиентов -->
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+    <div class="clients-grid">
         @foreach (var c in Model.Clients)
         {
-            // один раз материализуем, чтобы не итерировать несколько раз
             var envList = Model.Envs(c.Realm).ToList();
             var displayName = c.DisplayName;
             var subtitle = string.Equals(displayName, c.ClientId, StringComparison.OrdinalIgnoreCase)
@@ -29,45 +27,39 @@ else if (Model.Clients.Any())
 
             <a asp-page="/Clients/Details" asp-route-realm="@c.Realm" asp-route-clientId="@c.ClientId"
                asp-route-returnUrl="@returnUrl"
-               class="block group client-card"
-                data-search="@($"{c.ClientId} {c.Realm} {displayName}")">
-                <div class="kc-card kc-card--hover p-5 h-44 overflow-hidden transition relative">
-                    <!-- лёгкая подсветка по ховеру -->
-                    <div class="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition duration-500"
-                         style="background:
-                                         radial-gradient(480px 140px at 60% 18%, rgba(45,212,191,.12), transparent 70%),
-                                         radial-gradient(520px 180px at 10% 100%, rgba(99,102,241,.10), transparent 75%)"></div>
-
-                    <!-- Контур-линия окружений (внизу карточки) -->
+               class="client-card group"
+               data-search="@($"{c.ClientId} {c.Realm} {displayName}")">
+                <div class="client-card__surface">
                     @if (envList.Any())
                     {
-                        <div class="absolute inset-x-0 top-0 h-[4px] flex overflow-hidden">
+                        <div class="client-card__stripe">
                             @foreach (var e in envList)
                             {
-                                <span class="flex-1 h-full bg-gradient-to-r @Model.EnvBarGradient(e)"></span>
+                                <span class="client-card__stripe-segment bg-gradient-to-r @Model.EnvBarGradient(e)"></span>
                             }
                         </div>
                     }
 
-                    <div class="relative h-full flex flex-col">
-                        <!-- Заголовок + статус -->
-                        <div class="flex items-start justify-between">
-                            <div class="text-slate-100 font-semibold text-lg truncate">@c.ClientId</div>
-                            <span class="inline-flex items-center rounded-full px-2 py-1 text-[11px] border border-white/10 @(c.Enabled ? "bg-emerald-500/20 text-emerald-200" : "bg-rose-500/20 text-rose-200")">
+                    <div class="client-card__body">
+                        <div class="client-card__header">
+                            <div class="client-card__title">@c.ClientId</div>
+                            <span class="client-card__status @(c.Enabled ? "client-card__status--enabled" : "client-card__status--disabled")">
                                 @(c.Enabled ? "Enabled" : "Disabled")
                             </span>
                         </div>
 
-                        <!-- Описание -->
-                        <div class="text-slate-300/90 text-[15px] mt-1 line-clamp-2">
-                            @subtitle
-                        </div>
+                        <div class="client-card__subtitle">@subtitle</div>
 
-                        <!-- Окружения (чипы) -->
-                        <div class="mt-auto pt-3 flex items-center gap-2 flex-wrap">
-                            @foreach (var e in envList)
+                        <div class="client-card__footer">
+                            <div class="client-card__realm">@c.Realm?.ToUpperInvariant()</div>
+                            @if (envList.Any())
                             {
-                                <span class="kc-chip">@e</span>
+                                <div class="client-card__envs">
+                                    @foreach (var e in envList)
+                                    {
+                                        <span class="client-chip">@e</span>
+                                    }
+                                </div>
                             }
                         </div>
                     </div>
@@ -78,13 +70,13 @@ else if (Model.Clients.Any())
 
     @if (Model.TotalPages > 1)
     {
-        <div class="flex justify-center mt-6">
-            <nav class="flex items-center gap-2">
+        <div class="clients-pagination">
+            <nav class="clients-pagination__inner">
                 @if (Model.HasPreviousPage)
                 {
                     <a asp-page="@currentPage" asp-route-q="@Model.Q" asp-route-pageNumber="@(Model.PageNumber - 1)" class="btn-subtle">Previous</a>
                 }
-                <span class="text-sm text-slate-400">Page @Model.PageNumber of @Model.TotalPages</span>
+                <span class="clients-pagination__meta">Page @Model.PageNumber of @Model.TotalPages</span>
                 @if (Model.HasNextPage)
                 {
                     <a asp-page="@currentPage" asp-route-q="@Model.Q" asp-route-pageNumber="@(Model.PageNumber + 1)" class="btn-subtle">Next</a>

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -625,3 +625,429 @@ body.page-loaded #app {
     }
 }
 
+/* ===== Clients dashboard ===== */
+.clients-stage {
+    position: relative;
+    border-radius: 26px;
+    padding: 2px;
+    background: linear-gradient(140deg, rgba(236, 72, 153, 0.45), rgba(99, 102, 241, 0.7));
+    box-shadow: 0 38px 90px rgba(8, 10, 24, 0.55);
+    margin-bottom: 2.5rem;
+}
+
+.clients-stage::before {
+    content: "";
+    position: absolute;
+    inset: -30% -20%;
+    z-index: -2;
+    background:
+        radial-gradient(500px 420px at 20% 20%, rgba(236, 72, 153, 0.45), transparent 65%),
+        radial-gradient(560px 420px at 80% 90%, rgba(59, 130, 246, 0.38), transparent 70%);
+    filter: blur(42px);
+    opacity: .85;
+}
+
+.clients-stage::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.02));
+    opacity: .08;
+    pointer-events: none;
+}
+
+.clients-surface {
+    position: relative;
+    background: rgba(10, 13, 24, 0.92);
+    border-radius: 24px;
+    padding: 2.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.04),
+        0 30px 80px rgba(6, 9, 20, 0.55);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    overflow: hidden;
+}
+
+.clients-surface::before {
+    content: "";
+    position: absolute;
+    inset: -25% 5% 40% 5%;
+    background: radial-gradient(420px 280px at 15% 10%, rgba(236, 72, 153, 0.22), transparent 70%);
+    opacity: .35;
+    pointer-events: none;
+}
+
+.clients-surface::after {
+    content: "";
+    position: absolute;
+    inset: 30% -15% -30% 45%;
+    background: radial-gradient(480px 420px at 75% 50%, rgba(56, 189, 248, 0.18), transparent 75%);
+    opacity: .28;
+    pointer-events: none;
+}
+
+.clients-toolbar {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.75rem;
+}
+
+.clients-heading {
+    max-width: 420px;
+}
+
+.clients-title {
+    font-size: 2.15rem;
+    line-height: 1.25;
+    font-weight: 600;
+    color: #fff;
+    letter-spacing: -0.015em;
+}
+
+.clients-subtitle {
+    margin-top: .65rem;
+    font-size: .95rem;
+    line-height: 1.6;
+    color: rgba(226, 232, 240, 0.78);
+}
+
+.clients-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 1rem;
+}
+
+.clients-search {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    padding: .6rem .95rem;
+    border-radius: 9999px;
+    background: rgba(16, 21, 36, 0.92);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    width: min(100%, 320px);
+    box-shadow: 0 22px 48px rgba(5, 8, 20, 0.55);
+    transition: border-color .2s ease, box-shadow .2s ease, transform .2s ease;
+    color: var(--kc-ink);
+}
+
+.clients-search:focus-within {
+    border-color: rgba(129, 140, 248, 0.45);
+    box-shadow: 0 28px 60px rgba(79, 70, 229, 0.45);
+}
+
+.clients-search__icon {
+    width: 18px;
+    height: 18px;
+    color: rgba(148, 163, 184, 0.82);
+    flex-shrink: 0;
+}
+
+.clients-search__input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: .95rem;
+    color: var(--kc-ink);
+}
+
+.clients-search__input::placeholder {
+    color: rgba(203, 213, 225, 0.55);
+}
+
+.clients-search__submit {
+    border: none;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.92), rgba(236, 72, 153, 0.85));
+    color: #fff;
+    padding: .45rem 1.05rem;
+    font-size: .75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    box-shadow: 0 18px 45px rgba(99, 102, 241, 0.45);
+    cursor: pointer;
+    transition: transform .2s ease, box-shadow .2s ease;
+}
+
+.clients-search__submit:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 24px 55px rgba(236, 72, 153, 0.45);
+}
+
+.clients-search--wide {
+    width: min(100%, 420px);
+}
+
+.clients-create {
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.96), rgba(236, 72, 153, 0.92));
+    box-shadow: 0 24px 55px rgba(79, 70, 229, 0.45);
+}
+
+.clients-create:hover {
+    box-shadow: 0 28px 65px rgba(236, 72, 153, 0.5);
+}
+
+.clients-info {
+    position: relative;
+    z-index: 1;
+    margin-top: 2rem;
+    padding: 1.4rem 1.6rem;
+    border-radius: 20px;
+    background: rgba(14, 18, 32, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 28px 65px rgba(8, 11, 23, 0.5);
+    color: rgba(226, 232, 240, 0.82);
+}
+
+.clients-info--muted {
+    color: rgba(203, 213, 225, 0.75);
+}
+
+.clients-info--empty {
+    text-align: center;
+}
+
+.clients-info__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #fff;
+}
+
+.clients-info__subtitle {
+    margin-top: .35rem;
+    font-size: .9rem;
+    color: rgba(203, 213, 225, 0.74);
+}
+
+.clients-grid {
+    position: relative;
+    z-index: 1;
+    margin-top: 2rem;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.client-card {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
+
+.client-card__surface {
+    position: relative;
+    height: 100%;
+    padding: 1.5rem;
+    border-radius: 22px;
+    background: linear-gradient(160deg, rgba(33, 39, 66, 0.96) 0%, rgba(17, 22, 38, 0.94) 55%, rgba(11, 15, 27, 0.92) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    box-shadow: 0 24px 55px rgba(5, 8, 20, 0.6);
+    transition: transform .25s ease, box-shadow .25s ease, border-color .25s ease;
+    overflow: hidden;
+}
+
+.client-card__surface::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background:
+        radial-gradient(200px 140px at 15% 12%, rgba(236, 72, 153, 0.28), transparent 75%),
+        radial-gradient(260px 180px at 95% 95%, rgba(45, 212, 191, 0.2), transparent 80%);
+    opacity: 0;
+    transition: opacity .25s ease;
+    pointer-events: none;
+}
+
+.client-card:hover .client-card__surface {
+    transform: translateY(-6px);
+    border-color: rgba(129, 140, 248, 0.45);
+    box-shadow: 0 32px 75px rgba(10, 13, 28, 0.75);
+}
+
+.client-card:hover .client-card__surface::before {
+    opacity: .9;
+}
+
+.client-card__stripe {
+    position: absolute;
+    inset: 0;
+    top: 0;
+    height: 4px;
+    display: flex;
+    overflow: hidden;
+    border-radius: 22px 22px 0 0;
+}
+
+.client-card__stripe-segment {
+    flex: 1;
+}
+
+.client-card__body {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    height: 100%;
+}
+
+.client-card__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: .75rem;
+}
+
+.client-card__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #fff;
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.client-card__status {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;
+    padding: .32rem .7rem;
+    font-size: .68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    border: 1px solid transparent;
+}
+
+.client-card__status--enabled {
+    background: rgba(16, 185, 129, 0.16);
+    color: rgba(16, 185, 129, 0.92);
+    border-color: rgba(16, 185, 129, 0.32);
+}
+
+.client-card__status--disabled {
+    background: rgba(248, 113, 113, 0.2);
+    color: rgba(248, 113, 113, 0.92);
+    border-color: rgba(248, 113, 113, 0.32);
+}
+
+.client-card__subtitle {
+    font-size: .92rem;
+    line-height: 1.5;
+    color: rgba(226, 232, 240, 0.8);
+    min-height: 2.7rem;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.client-card__footer {
+    margin-top: auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .85rem;
+    flex-wrap: wrap;
+}
+
+.client-card__realm {
+    font-size: .75rem;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.82);
+}
+
+.client-card__envs {
+    display: flex;
+    align-items: center;
+    gap: .45rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.client-chip {
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    padding: .25rem .6rem;
+    border-radius: 9999px;
+    background: rgba(99, 102, 241, 0.16);
+    border: 1px solid rgba(99, 102, 241, 0.35);
+    color: rgba(226, 232, 240, 0.95);
+}
+
+.clients-pagination {
+    position: relative;
+    z-index: 1;
+    margin-top: 2.5rem;
+    display: flex;
+    justify-content: center;
+}
+
+.clients-pagination__inner {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    padding: .45rem .85rem;
+    border-radius: 9999px;
+    background: rgba(13, 17, 30, 0.88);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 22px 55px rgba(7, 9, 20, 0.55);
+}
+
+.clients-pagination__meta {
+    font-size: .78rem;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: rgba(148, 163, 184, 0.86);
+}
+
+@media (max-width: 768px) {
+    .clients-surface {
+        padding: 1.75rem;
+    }
+
+    .clients-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .clients-heading {
+        max-width: none;
+    }
+
+    .clients-actions {
+        justify-content: flex-start;
+    }
+
+    .clients-search,
+    .clients-search--wide {
+        width: 100%;
+    }
+}
+
+@media (max-width: 480px) {
+    .clients-stage {
+        border-radius: 20px;
+    }
+
+    .clients-surface {
+        border-radius: 18px;
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace the index and search layouts with a glassmorphism panel, shared toolbar, and updated actions
- restyle the shared clients list with the new card, pagination, and empty states visuals
- add a dedicated stylesheet section that implements the gradient backdrop, controls, and card theming

## Testing
- dotnet build *(fails: dotnet not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16c1d0664832db4ffaf9504b1f260