### PR TITLE
Show flash toast on client search page

### DIFF
--- a/Pages/Clients/Search.cshtml
+++ b/Pages/Clients/Search.cshtml
@@ -51,3 +51,18 @@
 <div id="clientsContainer">
     @await Html.PartialAsync("_ClientsList", Model)
 </div>
+
+@section Toasts {
+    @if (TempData["FlashOk"] is string flash)
+    {
+        <div class="kc-toast kc-toast-success" id="flashToast" role="alert">
+            <div class="kc-toast-icon">✓</div>
+            <div class="kc-toast-body">
+                <div class="kc-toast-title">@flash</div>
+            </div>
+            <button type="button" class="kc-toast-close" aria-label="Закрыть"
+                    onclick="this.closest('.kc-toast').remove()">×</button>
+        </div>
+        <script data-soft-nav>setTimeout(() => document.getElementById('flashToast')?.remove(), 10000);</script>
+    }
+}


### PR DESCRIPTION
## Summary
- render FlashOk success toast on the admin client search page so creation messages appear immediately

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d31704eae4832da7b7cca17d295866