### PR TITLE
Adjust event type filter dropdown theme

### DIFF
--- a/Pages/Admin/Events.cshtml
+++ b/Pages/Admin/Events.cshtml
@@ -77,7 +77,7 @@
         </div>
         <div class="flex flex-col gap-1">
             <label class="text-xs uppercase tracking-wide text-slate-400">Тип события</label>
-            <select name="OperationType" class="rounded-xl bg-white/5 border border-white/10 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:border-white/20">
+            <select name="OperationType" class="kc-input kc-select rounded-xl px-3 py-2 text-sm text-slate-100 focus:outline-none focus:border-white/20">
                 <option value="">Все типы</option>
                 @foreach (var type in Model.OperationTypes)
                 {

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -118,7 +118,7 @@
         color: rgba(226,232,240,.6);
     }
 
-.kc-select 
+.kc-select
 {
     appearance: none;
     -webkit-appearance: none;
@@ -128,6 +128,14 @@
     background-repeat: no-repeat;
     background-size: 12px;
     background-position: right 12px center;
+    background-color: #0a0f18;
+    color: var(--kc-ink);
+}
+
+.kc-select option
+{
+    background-color: #0a0f18;
+    color: var(--kc-ink);
 }
 
 


### PR DESCRIPTION
## Summary
- restyle the event type filter select to use the shared dark-themed styling
- update select styles so the opened dropdown matches the dark interface palette

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3abcece4c832d9fa85416542f5077