### PR TITLE
Scope soft navigation transition on client search

### DIFF
--- a/Pages/Clients/Search.cshtml
+++ b/Pages/Clients/Search.cshtml
@@ -23,7 +23,8 @@
         </div>
 
         <div class="flex items-center gap-3 w-full md:w-auto">
-            <form method="get" class="flex items-center gap-3 w-full md:w-auto">
+            <form method="get" class="flex items-center gap-3 w-full md:w-auto"
+                  data-soft-transition="#clientsResults">
                 <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[320px] focus-within:border-white/20">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <circle cx="11" cy="11" r="8" />
@@ -41,15 +42,17 @@
     </div>
 </div>
 
-@if (string.IsNullOrEmpty(Model.Q))
-{
-    <div class="kc-card mb-5 p-5 text-sm text-slate-300/90">
-        Введите идентификатор клиента, чтобы получить результаты поиска по всем доступным реалмам.
-    </div>
-}
+<div id="clientsResults" class="space-y-5">
+    @if (string.IsNullOrEmpty(Model.Q))
+    {
+        <div class="kc-card p-5 text-sm text-slate-300/90">
+            Введите идентификатор клиента, чтобы получить результаты поиска по всем доступным реалмам.
+        </div>
+    }
 
-<div id="clientsContainer">
-    @await Html.PartialAsync("_ClientsList", Model)
+    <div id="clientsContainer">
+        @await Html.PartialAsync("_ClientsList", Model)
+    </div>
 </div>
 
 @section Toasts {

--- a/Pages/Shared/_ClientsList.cshtml
+++ b/Pages/Shared/_ClientsList.cshtml
@@ -82,12 +82,20 @@ else if (Model.Clients.Any())
             <nav class="flex items-center gap-2">
                 @if (Model.HasPreviousPage)
                 {
-                    <a asp-page="@currentPage" asp-route-q="@Model.Q" asp-route-pageNumber="@(Model.PageNumber - 1)" class="btn-subtle">Previous</a>
+                    <form method="get" asp-page="@currentPage" class="inline-flex" data-soft-transition="#clientsResults">
+                        <input type="hidden" name="q" value="@Model.Q" />
+                        <input type="hidden" name="pageNumber" value="@(Model.PageNumber - 1)" />
+                        <button type="submit" class="btn-subtle">Previous</button>
+                    </form>
                 }
                 <span class="text-sm text-slate-400">Page @Model.PageNumber of @Model.TotalPages</span>
                 @if (Model.HasNextPage)
                 {
-                    <a asp-page="@currentPage" asp-route-q="@Model.Q" asp-route-pageNumber="@(Model.PageNumber + 1)" class="btn-subtle">Next</a>
+                    <form method="get" asp-page="@currentPage" class="inline-flex" data-soft-transition="#clientsResults">
+                        <input type="hidden" name="q" value="@Model.Q" />
+                        <input type="hidden" name="pageNumber" value="@(Model.PageNumber + 1)" />
+                        <button type="submit" class="btn-subtle">Next</button>
+                    </form>
                 }
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- scope the Clients/Search soft navigation transition to the results container so the header stays static when reloading content
- wrap the empty-state and results list in a shared container for consistent transitions
- convert pagination links into GET forms that reuse the scoped transition for smooth paging animations

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ada90464832dac1281532c1b277d