### PR TITLE
Ensure Confluence page labels are applied after creation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -43,6 +43,8 @@ builder.Services.AddScoped<IClientsProvider, DbClientsProvider>();
 builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection("Email"));
 builder.Services.AddScoped<IAccessRequestEmailSender, AccessRequestEmailSender>();
 var confluenceOptions = ConfluenceOptions.FromConnectionString(builder.Configuration.GetConnectionString("ConnectionWiki"));
+var confluenceLabels = builder.Configuration.GetSection("Confluence:Labels").Get<string[]>();
+confluenceOptions.SetLabels(confluenceLabels);
 builder.Services.AddSingleton(confluenceOptions);
 builder.Services.AddSingleton<ConfluenceTemplateProvider>();
 builder.Services.AddHttpClient("confluence-wiki", client =>

--- a/Services/ConfluenceOptions.cs
+++ b/Services/ConfluenceOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 
 namespace Assistant.Services;
@@ -10,6 +11,9 @@ public sealed class ConfluenceOptions
     public string? Password { get; private set; }
     public string? SpaceKey { get; private set; }
     public long? ParentPageId { get; private set; }
+    public IReadOnlyList<string> Labels => _labels;
+
+    private string[] _labels = Array.Empty<string>();
 
     public bool IsConfigured =>
         !string.IsNullOrWhiteSpace(BaseUrl)
@@ -45,6 +49,34 @@ public sealed class ConfluenceOptions
         }
 
         return options;
+    }
+
+    public void SetLabels(IEnumerable<string>? labels)
+    {
+        if (labels is null)
+        {
+            _labels = Array.Empty<string>();
+            return;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+
+        foreach (var label in labels)
+        {
+            var trimmed = label?.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                continue;
+            }
+
+            if (seen.Add(trimmed))
+            {
+                result.Add(trimmed);
+            }
+        }
+
+        _labels = result.Count == 0 ? Array.Empty<string>() : result.ToArray();
     }
 
     private static string? GetString(DbConnectionStringBuilder builder, string key)

--- a/Services/ConfluenceWikiService.cs
+++ b/Services/ConfluenceWikiService.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 
 namespace Assistant.Services;
@@ -71,12 +72,95 @@ public sealed class ConfluenceWikiService
                     payload.ClientId,
                     response.StatusCode,
                     message);
+                return;
             }
+
+            if (_options.Labels.Count == 0)
+            {
+                return;
+            }
+
+            var pageId = await TryExtractPageIdAsync(response.Content, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(pageId))
+            {
+                _logger.LogWarning(
+                    "Created Confluence page for {ClientId}, but the page id could not be determined to add labels.",
+                    payload.ClientId);
+                return;
+            }
+
+            await AddLabelsAsync(client, pageId, payload, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while creating Confluence page for {ClientId}.", payload.ClientId);
         }
+    }
+
+    private async Task AddLabelsAsync(HttpClient client, string pageId, ClientWikiPayload payload, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var request = JsonContent.Create(
+                _options.Labels.Select(label => new { prefix = "global", name = label }).ToArray(),
+                options: new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+            using var response = await client.PostAsync($"/rest/api/content/{pageId}/label", request, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.Conflict)
+            {
+                _logger.LogDebug(
+                    "Confluence labels already exist for page {PageId} ({ClientId}). Response: {Response}",
+                    pageId,
+                    payload.ClientId,
+                    body);
+                return;
+            }
+
+            _logger.LogError(
+                "Failed to add labels to Confluence page {PageId} for {ClientId}. StatusCode: {Status}. Response: {Response}",
+                pageId,
+                payload.ClientId,
+                response.StatusCode,
+                body);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Unexpected error while adding labels to Confluence page {PageId} for {ClientId}.",
+                pageId,
+                payload.ClientId);
+        }
+    }
+
+    private static async Task<string?> TryExtractPageIdAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (document.RootElement.TryGetProperty("id", out var idProperty))
+            {
+                var id = idProperty.GetString();
+                return string.IsNullOrWhiteSpace(id) ? null : id;
+            }
+        }
+        catch (Exception)
+        {
+            // Ignore parsing errors and let the caller handle the missing id scenario.
+        }
+
+        return null;
     }
 
     private void PrepareClient(HttpClient client)

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -9,5 +9,11 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Database=assistant;Username=assistant;Password=assistant",
     "ConnectionWiki": "BaseUrl=http://localhost:8090/;User=admin;Password=admin;SpaceKey=DOM;ParentId=131148"
+  },
+  "Confluence": {
+    "Labels": [
+      "keycloak",
+      "assistant"
+    ]
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -24,6 +24,12 @@
     "DefaultConnection": "Host=localhost;Database=assistant;Username=assistant;Password=assistant",
     "ConnectionWiki": "BaseUrl=http://localhost:8090/;User=admin;Password=admin;SpaceKey=DOM;ParentId=131148"
   },
+  "Confluence": {
+    "Labels": [
+      "keycloak",
+      "assistant"
+    ]
+  },
   "App": {
     "BaseUrl": "http://localhost:5000" // для post-logout редиректа. В DEV можно http://localhost:5000
   },


### PR DESCRIPTION
## Summary
- add a follow-up request that applies configured labels to newly created Confluence pages
- parse the page identifier from the create response so the label request targets the correct page
- improve logging around label application failures and unexpected response formats

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3c39bf104832daa317ba897284ae3