### PR TITLE
Add Confluence labels configuration and apply after page creation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -42,7 +42,8 @@ builder.Services.AddSingleton<ApiLogRepository>();
 builder.Services.AddScoped<IClientsProvider, DbClientsProvider>();
 builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection("Email"));
 builder.Services.AddScoped<IAccessRequestEmailSender, AccessRequestEmailSender>();
-var confluenceOptions = ConfluenceOptions.FromConnectionString(builder.Configuration.GetConnectionString("ConnectionWiki"));
+var confluenceLabels = builder.Configuration.GetSection("Confluence").GetSection("Labels").Get<string[]?>();
+var confluenceOptions = ConfluenceOptions.FromConnectionString(builder.Configuration.GetConnectionString("ConnectionWiki"), confluenceLabels);
 builder.Services.AddSingleton(confluenceOptions);
 builder.Services.AddSingleton<ConfluenceTemplateProvider>();
 builder.Services.AddHttpClient("confluence-wiki", client =>

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -9,5 +9,11 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Database=assistant;Username=assistant;Password=assistant",
     "ConnectionWiki": "BaseUrl=http://localhost:8090/;User=admin;Password=admin;SpaceKey=DOM;ParentId=131148"
+  },
+  "Confluence": {
+    "Labels": [
+      "assistant",
+      "wiki"
+    ]
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -35,6 +35,12 @@
     "EnableSsl": true,
     "Username": "smtp-user",
     "Password": "smtp-password"
+  },
+  "Confluence": {
+    "Labels": [
+      "assistant",
+      "wiki"
+    ]
   }
 
 }


### PR DESCRIPTION
## Summary
- allow configuring default Confluence labels via appsettings
- store the configured labels in ConfluenceOptions and pass them to ConfluenceWikiService
- assign configured labels to new Confluence pages immediately after creation and log failures

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cd72d190832d855f0bb10bc58cbc