### PR TITLE
Add realm label to Confluence wiki pages

### DIFF
--- a/Services/ConfluenceWikiService.cs
+++ b/Services/ConfluenceWikiService.cs
@@ -84,7 +84,7 @@ public sealed class ConfluenceWikiService
                 return;
             }
 
-            await AddLabelsAsync(client, created.Id, serializerOptions, payload.ClientId, cancellationToken)
+            await AddLabelsAsync(client, created.Id, serializerOptions, payload.ClientId, payload.Realm, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -119,14 +119,11 @@ public sealed class ConfluenceWikiService
         string pageId,
         JsonSerializerOptions serializerOptions,
         string clientId,
+        string realm,
         CancellationToken cancellationToken)
     {
-        if (_options.Labels.Count == 0)
-        {
-            return;
-        }
+        var labels = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var payload = new List<object>(_options.Labels.Count);
         foreach (var label in _options.Labels)
         {
             if (string.IsNullOrWhiteSpace(label))
@@ -134,6 +131,22 @@ public sealed class ConfluenceWikiService
                 continue;
             }
 
+            labels.Add(label.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(realm))
+        {
+            labels.Add(realm.Trim());
+        }
+
+        if (labels.Count == 0)
+        {
+            return;
+        }
+
+        var payload = new List<object>(labels.Count);
+        foreach (var label in labels)
+        {
             payload.Add(new { prefix = "global", name = label });
         }
 


### PR DESCRIPTION
## Summary
- append the client's realm as an additional Confluence label alongside configured labels
- ensure label payload construction de-duplicates configured labels and realm values before applying them

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d331a084832d9259cc71375f1bb7