### PR TITLE
Adjust client card realm gradient mapping

### DIFF
--- a/Pages/ClientsPageModel.cs
+++ b/Pages/ClientsPageModel.cs
@@ -24,14 +24,24 @@ public abstract class ClientsPageModel : PageModel
 
     public bool HasNextPage => PageNumber < TotalPages;
 
-    public string MapEnv(string? v) => (v ?? "").Trim().ToLowerInvariant() switch
+    public string MapEnv(string? v)
     {
-        "prod" or "production" => "PROD",
-        "stage" or "staging" => "STAGE",
-        "test" => "TEST",
-        "dev" or "development" => "TEST",
-        _ => (v ?? "").ToUpperInvariant()
-    };
+        var normalized = (v ?? string.Empty).Trim();
+
+        if (string.IsNullOrEmpty(normalized))
+        {
+            return string.Empty;
+        }
+
+        return normalized.ToLowerInvariant() switch
+        {
+            "prod" or "production" => "PROD",
+            "stage" or "staging" => "STAGE",
+            "test" => "TEST",
+            "dev" or "development" => "TEST",
+            _ => normalized
+        };
+    }
 
     public IEnumerable<string> Envs(string? raw)
         => string.IsNullOrWhiteSpace(raw)
@@ -40,11 +50,14 @@ public abstract class ClientsPageModel : PageModel
                  .Select(MapEnv)
                  .Distinct(StringComparer.OrdinalIgnoreCase);
 
-    public string EnvBarGradient(string? env) => (env ?? "").ToUpperInvariant() switch
+    public string EnvBarGradient(string? env) => (env ?? string.Empty).Trim().ToLowerInvariant() switch
     {
-        "PROD" => "from-fuchsia-500/70 to-pink-500/70",
-        "STAGE" => "from-amber-400/80 to-orange-500/70",
-        "TEST" => "from-emerald-400/80 to-teal-500/70",
+        "prod" => "from-fuchsia-500/70 to-pink-500/70",
+        "stage" => "from-amber-400/80 to-orange-500/70",
+        "test" => "from-emerald-400/80 to-teal-500/70",
+        "internal-bank-idm" => "from-sky-500/70 to-blue-500/70",
+        "external-bank-idm" => "from-violet-500/70 to-purple-500/70",
+        "external-dbofl-idm" => "from-rose-500/70 to-orange-400/70",
         _ => "from-slate-500/60 to-slate-400/60"
     };
 


### PR DESCRIPTION
## Summary
- allow environment mapping to preserve original realm names instead of forcing uppercase
- add explicit gradient styles for internal-bank-idm, external-bank-idm, and external-dbofl-idm realms so the client card header reflects the realm

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f47d49c4832db9c174898e0310c5