### PR TITLE
Add realm link support for Confluence wiki pages

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -47,6 +47,7 @@ var confluenceLabels = builder.Configuration.GetSection("Confluence").GetSection
 var confluenceOptions = ConfluenceOptions.FromConnectionString(builder.Configuration.GetConnectionString("ConnectionWiki"), confluenceLabels);
 builder.Services.AddSingleton(confluenceOptions);
 builder.Services.AddSingleton<ConfluenceTemplateProvider>();
+builder.Services.AddSingleton<RealmLinkProvider>();
 builder.Services.AddHttpClient("confluence-wiki", client =>
 {
     client.Timeout = TimeSpan.FromSeconds(100);

--- a/Services/ConfluenceWikiService.cs
+++ b/Services/ConfluenceWikiService.cs
@@ -15,17 +15,20 @@ public sealed class ConfluenceWikiService
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ConfluenceTemplateProvider _templateProvider;
     private readonly ConfluenceOptions _options;
+    private readonly RealmLinkProvider _realmLinkProvider;
     private readonly ILogger<ConfluenceWikiService> _logger;
 
     public ConfluenceWikiService(
         IHttpClientFactory httpClientFactory,
         ConfluenceTemplateProvider templateProvider,
         ConfluenceOptions options,
+        RealmLinkProvider realmLinkProvider,
         ILogger<ConfluenceWikiService> logger)
     {
         _httpClientFactory = httpClientFactory;
         _templateProvider = templateProvider;
         _options = options;
+        _realmLinkProvider = realmLinkProvider;
         _logger = logger;
     }
 
@@ -292,7 +295,7 @@ public sealed class ConfluenceWikiService
         return $"Конфигурация клиента {clientId}";
     }
 
-    private static string BuildHtml(string template, ClientWikiPayload payload)
+    private string BuildHtml(string template, ClientWikiPayload payload)
     {
         var replacements = new Dictionary<string, string>
         {
@@ -336,8 +339,16 @@ public sealed class ConfluenceWikiService
         return $"<td>{name}</td>";
     }
 
-    private static string BuildRealmCell(string realm)
-        => $"<td>{WebUtility.HtmlEncode(realm)}</td>";
+    private string BuildRealmCell(string realm)
+    {
+        var encodedRealm = WebUtility.HtmlEncode(realm);
+        if (_realmLinkProvider.TryGetRealmLink(realm, out var link))
+        {
+            return $"<td><a href=\"{WebUtility.HtmlEncode(link)}\">{encodedRealm}</a></td>";
+        }
+
+        return $"<td>{encodedRealm}</td>";
+    }
 
     private static string BuildDescription(string? description)
     {

--- a/Services/RealmLinkProvider.cs
+++ b/Services/RealmLinkProvider.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Assistant.Services;
+
+public sealed class RealmLinkProvider
+{
+    private readonly IReadOnlyDictionary<string, string> _links;
+
+    public RealmLinkProvider(IHostEnvironment environment, ILogger<RealmLinkProvider> logger)
+    {
+        var path = Path.Combine(environment.ContentRootPath, "link_realms.json");
+        if (!File.Exists(path))
+        {
+            logger.LogWarning("Realm links file was not found at {Path}.", path);
+            _links = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            return;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            var data = JsonSerializer.Deserialize<Dictionary<string, string>>(stream, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            if (data is null || data.Count == 0)
+            {
+                _links = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                return;
+            }
+
+            var comparer = StringComparer.OrdinalIgnoreCase;
+            var normalized = new Dictionary<string, string>(data.Count, comparer);
+            foreach (var pair in data)
+            {
+                if (string.IsNullOrWhiteSpace(pair.Key) || string.IsNullOrWhiteSpace(pair.Value))
+                {
+                    continue;
+                }
+
+                normalized[pair.Key.Trim()] = pair.Value.Trim();
+            }
+
+            _links = normalized;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to read realm links from {Path}.", path);
+            _links = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    public bool TryGetRealmLink(string? realm, out string link)
+    {
+        link = string.Empty;
+        if (string.IsNullOrWhiteSpace(realm))
+        {
+            return false;
+        }
+
+        if (_links.TryGetValue(realm, out var value) && !string.IsNullOrWhiteSpace(value))
+        {
+            link = value;
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- load realm link mappings from the new link_realms.json configuration file
- inject the mappings into Confluence wiki generation to render realm names as links when available
- register the realm link provider in the application container

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4580a5134832d9b30a94b05a6f27d