### PR TITLE
Add admin-only confidential client automation on Create wizard

### DIFF
--- a/Assistant.csproj
+++ b/Assistant.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.8" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -26,7 +26,7 @@
     <!-- Stepper -->
     <div class="kc-card md:max-w-[1000px] mx-auto">
         <div class="p-5">
-            <div class="grid grid-cols-7 gap-1">
+            <div class="flex flex-wrap gap-1">
                 <div class="step" id="stepHead1"><div class="dot">1</div><div class="label">Realm</div></div>
                 <div class="step" id="stepHead2"><div class="dot">2</div><div class="label">Basics</div></div>
                 <div class="step" id="stepHead3"><div class="dot">3</div><div class="label">System info</div></div>
@@ -34,6 +34,10 @@
                 <div class="step" id="stepHead5"><div class="dot">5</div><div class="label">Redirect URIs</div></div>
                 <div class="step" id="stepHead6"><div class="dot">6</div><div class="label">Local roles</div></div>
                 <div class="step" id="stepHead7"><div class="dot">7</div><div class="label">Service roles</div></div>
+                @if (Model.IsAdmin)
+                {
+                    <div class="step" id="stepHead8"><div class="dot">8</div><div class="label">Creatio</div></div>
+                }
             </div>
             <div class="mt-3 divider"></div>
         </div>
@@ -52,6 +56,8 @@
             <input type="hidden" asp-for="AppUrl" id="hidAppUrl" />
             <input type="hidden" asp-for="ServiceOwner" id="hidServiceOwner" />
             <input type="hidden" asp-for="ServiceManager" id="hidServiceManager" />
+            <input type="hidden" asp-for="CreatioRequestNumber" id="hidCreatioNumber" />
+            <input type="hidden" asp-for="ArchivePasswordEmail" id="hidArchiveEmail" />
 
             <!-- Шаг 1: Realm -->
             <div class="space-y-4" id="step-1" data-step="1">
@@ -271,6 +277,41 @@
                 </div>
             </div>
 
+            @if (Model.IsAdmin)
+            {
+                <!-- Шаг 8: Creatio -->
+                <div class="space-y-4 hidden" id="step-8" data-step="8">
+                    <div class="text-slate-200 font-semibold text-lg">8. Дополнительные данные</div>
+
+                    <div class="grid md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm text-slate-400 mb-1">Номер заявки Creatio <span class="text-rose-500">*</span></label>
+                            <input id="creatioNumber"
+                                   value="@(Model.CreatioRequestNumber ?? string.Empty)"
+                                   maxlength="64"
+                                   class="kc-input kc-select-dark rounded-xl px-3 py-2 text-sm w-full"
+                                   placeholder="Например: CR-12345"
+                                   autocomplete="off" autocapitalize="off" spellcheck="false" />
+                            <div id="errCreatio" class="err">Укажите номер заявки Creatio.</div>
+                        </div>
+
+                        <div>
+                            <label class="block text-sm text-slate-400 mb-1">Email для пароля <span class="text-rose-500">*</span></label>
+                            <input id="archiveEmail"
+                                   value="@(Model.ArchivePasswordEmail ?? string.Empty)"
+                                   maxlength="100"
+                                   type="email"
+                                   class="kc-input kc-select-dark rounded-xl px-3 py-2 text-sm w-full"
+                                   placeholder="name@example.com"
+                                   autocomplete="off" autocapitalize="off" spellcheck="false" />
+                            <div id="errArchiveEmail" class="err">Укажите корректный email.</div>
+                        </div>
+                    </div>
+
+                    <div class="hint">Пароль от архива будет отправлен на указанный email.</div>
+                </div>
+            }
+
             <!-- Навигация -->
             <div class="wizard-nav mt-6">
                 <button type="button" class="btn-subtle" id="btnPrev">Back</button>
@@ -281,6 +322,25 @@
                 </div>
             </div>
         </form>
+    </div>
+</div>
+
+<div id="creationModal" class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-950/70 px-4">
+    <div class="kc-card relative w-full max-w-xl p-6">
+        <button type="button" class="absolute top-3 right-3 text-slate-400 hover:text-slate-200" data-modal-close>&times;</button>
+        <div class="text-xl text-slate-100 font-semibold">Конфигурация создана</div>
+        <div class="mt-4 space-y-2 text-slate-300 text-sm" id="creationModalBody">
+            <p>Создана конфигурация в TEST среде.</p>
+            <p><span class="text-slate-400">Base URL:</span> <span data-modal-base-url>—</span></p>
+            <p><span class="text-slate-400">Realm:</span> <span data-modal-realm>—</span></p>
+            <p><span class="text-slate-400">ClientID:</span> <span data-modal-client>—</span></p>
+            <p><span class="text-slate-400">Secret:</span> в архиве, пароль от архива выслан на почту.</p>
+            <p><span class="text-slate-400">Ссылка на конфигурацию в реестре:</span> <a href="#" data-modal-wiki target="_blank" rel="noopener" class="text-indigo-300 underline break-all">—</a></p>
+            <p><span class="text-slate-400">Endpoints:</span> <a href="#" data-modal-endpoints target="_blank" rel="noopener" class="text-indigo-300 underline break-all">—</a></p>
+        </div>
+        <div class="mt-6 text-right">
+            <button type="button" class="btn-subtle" data-modal-close>Закрыть</button>
+        </div>
     </div>
 </div>
 
@@ -350,6 +410,13 @@
           const swStandard   = $('#swStandard');
           const swService    = $('#swService');
 
+          // Admin step
+          const isAdmin = @(Model.IsAdmin ? "true" : "false");
+          const creatioInput = $('#creatioNumber');
+          const archiveEmailInput = $('#archiveEmail');
+          const errCreatio = $('#errCreatio');
+          const errArchiveEmail = $('#errArchiveEmail');
+
           // AC (шаг 3)
           const appNameInput = $('#appName');
           const appUrlInput  = $('#appUrl');
@@ -375,6 +442,8 @@
           const hidAppUrl        = $('#hidAppUrl');
           const hidServiceOwner  = $('#hidServiceOwner');
           const hidServiceManager= $('#hidServiceManager');
+          const hidCreatioNumber = $('#hidCreatioNumber');
+          const hidArchiveEmail  = $('#hidArchiveEmail');
 
           // ---- Chips data
           const redirs   = @Html.Raw(string.IsNullOrWhiteSpace(Model.RedirectUrisJson) ? "[]" : Model.RedirectUrisJson);
@@ -390,10 +459,13 @@
           const stepNum = (el)=> +el.getAttribute('data-step') || +el.id.replace('stepHead','');
 
           // Условия включения шагов
+          const requiresAdminStep = () => isAdmin && (swClientAuth?.checked ?? false);
+
           const predicates =
           {
             5: ()=> swStandard?.checked ?? true,
             7: ()=> swService?.checked  ?? false,
+            8: ()=> requiresAdminStep(),
           };
 
           const enabledSteps = () =>
@@ -419,6 +491,8 @@
             $('#errRealm')?.classList.remove('show');
             errCid?.classList.remove('show');
             errAppName?.classList.remove('show');
+            errCreatio?.classList.remove('show');
+            errArchiveEmail?.classList.remove('show');
 
             if (n===1)
             {
@@ -432,6 +506,26 @@
             {
               if (!trim(appNameInput?.value)){ errAppName?.classList.add('show'); appNameInput?.focus(); return false; }
             }
+
+            if (n===8 && requiresAdminStep())
+            {
+              if (!trim(creatioInput?.value))
+              {
+                errCreatio?.classList.add('show');
+                creatioInput?.focus();
+                return false;
+              }
+
+              const emailVal = trim(archiveEmailInput?.value);
+              const emailValid = emailVal && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailVal);
+              if (!emailValid)
+              {
+                errArchiveEmail?.classList.add('show');
+                archiveEmailInput?.focus();
+                return false;
+              }
+            }
+
             return true;
           }
 
@@ -448,6 +542,12 @@
           }
           swClientAuth?.addEventListener('change', () => {
             if (swService?.checked) swClientAuth.checked = true;
+            const en = enabledSteps();
+            if (en.length)
+            {
+              if (!en.includes(current)) showStep(en[en.length-1]);
+              else showStep(current);
+            }
           });
 
           // ---- Step engine
@@ -570,6 +670,8 @@
             hidAppUrl.value         = trim(appUrlInput?.value);
             hidServiceOwner.value   = trim(ownerInput?.value);
             hidServiceManager.value = trim(managerInput?.value);
+            if (hidCreatioNumber) hidCreatioNumber.value = requiresAdminStep() ? trim(creatioInput?.value) : '';
+            if (hidArchiveEmail)  hidArchiveEmail.value  = requiresAdminStep() ? trim(archiveEmailInput?.value) : '';
 
             const submitter = (e.submitter instanceof HTMLElement) ? e.submitter : null;
             const loadingButton = submitter ?? btnCreate;
@@ -980,6 +1082,95 @@
           }
 
           realmEl?.addEventListener('change', safe(resetForRealmChange));
+        })();
+    </script>
+
+    @if (!string.IsNullOrEmpty(Model.ArchiveBase64) && !string.IsNullOrEmpty(Model.ArchiveFileName))
+    {
+        <script data-soft-nav>
+            window.__creationArchive = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(new { fileName = Model.ArchiveFileName, base64 = Model.ArchiveBase64 }));
+        </script>
+    }
+
+    @if (Model.SuccessInfo is not null)
+    {
+        <script data-soft-nav>
+            window.__creationSuccess = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.SuccessInfo));
+        </script>
+    }
+
+    <script data-soft-nav>
+        (() => {
+            const archive = window.__creationArchive;
+            if (archive?.base64 && archive?.fileName)
+            {
+                try
+                {
+                    const binary = atob(archive.base64);
+                    const len = binary.length;
+                    const bytes = new Uint8Array(len);
+                    for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
+                    const blob = new Blob([bytes], { type: 'application/zip' });
+                    const link = document.createElement('a');
+                    link.href = URL.createObjectURL(blob);
+                    link.download = archive.fileName;
+                    document.body.appendChild(link);
+                    link.click();
+                    setTimeout(() => {
+                        URL.revokeObjectURL(link.href);
+                        link.remove();
+                    }, 100);
+                }
+                catch (err)
+                {
+                    console.error('Failed to trigger archive download', err);
+                }
+                finally
+                {
+                    window.__creationArchive = null;
+                }
+            }
+
+            const modalInfo = window.__creationSuccess;
+            const modal = document.getElementById('creationModal');
+            if (!modal || !modalInfo)
+            {
+                return;
+            }
+
+            const setText = (selector, value, isLink = false) => {
+                const el = modal.querySelector(selector);
+                if (!el) return;
+                const text = value && value.trim() ? value : '—';
+                if (isLink)
+                {
+                    el.textContent = text;
+                    if (value && value.trim()) el.setAttribute('href', value);
+                    else el.removeAttribute('href');
+                }
+                else
+                {
+                    el.textContent = text;
+                }
+            };
+
+            setText('[data-modal-base-url]', modalInfo.baseUrl ?? '');
+            setText('[data-modal-realm]', modalInfo.realm ?? '');
+            setText('[data-modal-client]', modalInfo.clientId ?? '');
+            setText('[data-modal-wiki]', modalInfo.wikiUrl ?? '', true);
+            setText('[data-modal-endpoints]', modalInfo.endpointsUrl ?? '', true);
+
+            modal.classList.remove('hidden');
+            modal.classList.add('flex');
+
+            modal.querySelectorAll('[data-modal-close]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    modal.classList.add('hidden');
+                    modal.classList.remove('flex');
+                });
+            });
+
+            window.__creationSuccess = null;
         })();
     </script>
 }

--- a/Pages/Clients/Create.cshtml.cs
+++ b/Pages/Clients/Create.cshtml.cs
@@ -2,26 +2,38 @@ using Assistant.KeyCloak;
 using Assistant.KeyCloak.Models;
 using Assistant.Interfaces;
 using Assistant.Services;
+using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.IO;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Assistant.Pages.Clients;
 
 [Authorize(Roles = "assistant-user,assistant-admin")]
 public class CreateModel : PageModel
 {
+    private static readonly EmailAddressAttribute EmailValidator = new();
+
     private readonly RealmsService _realms;
     private readonly ClientsService _clients;
     private readonly UserClientsRepository _repo;
     private readonly ServiceRoleExclusionsRepository _exclusions;
     private readonly ConfluenceWikiService _wiki;
     private readonly ClientWikiRepository _wikiPages;
+    private readonly ISimpleEmailSender _emailSender;
+    private readonly ConfluenceOptions _confluenceOptions;
+    private readonly RealmLinkProvider _realmLinks;
+    private readonly AdminApiOptions _adminOptions;
     private readonly ILogger<CreateModel> _logger;
 
     public CreateModel(
@@ -31,6 +43,10 @@ public class CreateModel : PageModel
         ServiceRoleExclusionsRepository exclusions,
         ConfluenceWikiService wiki,
         ClientWikiRepository wikiPages,
+        ISimpleEmailSender emailSender,
+        ConfluenceOptions confluenceOptions,
+        RealmLinkProvider realmLinks,
+        IOptions<AdminApiOptions> adminOptions,
         ILogger<CreateModel> logger)
     {
         _realms = realms;
@@ -39,10 +55,16 @@ public class CreateModel : PageModel
         _exclusions = exclusions;
         _wiki = wiki;
         _wikiPages = wikiPages;
+        _emailSender = emailSender;
+        _confluenceOptions = confluenceOptions;
+        _realmLinks = realmLinks;
+        _adminOptions = adminOptions.Value;
         _logger = logger;
     }
 
     public int StepToShow { get; set; }
+
+    public bool IsAdmin { get; private set; }
 
     [BindProperty] public string? Realm { get; set; }
     public List<SelectListItem> RealmOptions { get; private set; } = new();
@@ -63,7 +85,20 @@ public class CreateModel : PageModel
     [BindProperty] public string? ServiceOwner { get; set; }
     [BindProperty] public string? ServiceManager { get; set; }
 
-    public async Task OnGet() => await LoadViewDataAsync();
+    [BindProperty] public string? CreatioRequestNumber { get; set; }
+    [BindProperty] public string? ArchivePasswordEmail { get; set; }
+
+    public string? ArchiveBase64 { get; private set; }
+    public string? ArchiveFileName { get; private set; }
+    public AdminCreationSummary? SuccessInfo { get; private set; }
+
+    public sealed record AdminCreationSummary(string BaseUrl, string Realm, string ClientId, string? WikiUrl, string? EndpointsUrl);
+
+    public async Task OnGet()
+    {
+        IsAdmin = User.IsInRole("assistant-admin");
+        await LoadViewDataAsync();
+    }
 
     private static bool IsValidClientId(string? id)
     {
@@ -103,11 +138,13 @@ public class CreateModel : PageModel
         if (Hit(nameof(RedirectUrisJson))) return 5;
         if (Hit(nameof(LocalRolesJson))) return 6;
         if (Hit(nameof(ServiceRolesJson))) return 7;
+        if (Hit(nameof(CreatioRequestNumber)) || Hit(nameof(ArchivePasswordEmail))) return 8;
         return 1;
     }
 
     private async Task LoadViewDataAsync()
     {
+        IsAdmin = User.IsInRole("assistant-admin");
         var names = await _realms.GetRealmsAsync();
         if (User.IsInRole("assistant-user") && !User.IsInRole("assistant-admin"))
         {
@@ -134,6 +171,13 @@ public class CreateModel : PageModel
 
     public async Task<IActionResult> OnPostCreate(CancellationToken ct)
     {
+        ArchiveBase64 = null;
+        ArchiveFileName = null;
+        SuccessInfo = null;
+        IsAdmin = User.IsInRole("assistant-admin");
+        CreatioRequestNumber = string.IsNullOrWhiteSpace(CreatioRequestNumber) ? null : CreatioRequestNumber.Trim();
+        ArchivePasswordEmail = string.IsNullOrWhiteSpace(ArchivePasswordEmail) ? null : ArchivePasswordEmail.Trim();
+
         await LoadViewDataAsync();
 
         if (string.IsNullOrWhiteSpace(Realm))
@@ -169,6 +213,24 @@ public class CreateModel : PageModel
         if (FlowService)
         {
             ClientAuth = true;
+        }
+
+        var requiresAdminExtras = IsAdmin && ClientAuth;
+        if (requiresAdminExtras)
+        {
+            if (string.IsNullOrWhiteSpace(CreatioRequestNumber))
+            {
+                ModelState.AddModelError(nameof(CreatioRequestNumber), "Укажите номер заявки Creatio.");
+            }
+
+            if (string.IsNullOrWhiteSpace(ArchivePasswordEmail))
+            {
+                ModelState.AddModelError(nameof(ArchivePasswordEmail), "Укажите email для пароля.");
+            }
+            else if (!EmailValidator.IsValid(ArchivePasswordEmail))
+            {
+                ModelState.AddModelError(nameof(ArchivePasswordEmail), "Некорректный email.");
+            }
         }
 
         var redirects = ClientFormUtilities.NormalizeDistinct(ClientFormUtilities.ParseStringList(RedirectUrisJson));
@@ -263,6 +325,7 @@ public class CreateModel : PageModel
                 ServiceManager: normalizedManager),
                 ct);
 
+            string? wikiUrl = null;
             if (!string.IsNullOrWhiteSpace(pageId))
             {
                 try
@@ -280,6 +343,60 @@ public class CreateModel : PageModel
                 {
                     _logger.LogError(ex, "Failed to persist Confluence wiki mapping for {ClientId}", spec.ClientId);
                 }
+
+                wikiUrl = BuildWikiUrl(pageId);
+            }
+
+            string? endpointsUrl = null;
+            if (_realmLinks.TryGetRealmLink(spec.Realm, out var link))
+            {
+                endpointsUrl = link;
+            }
+
+            if (IsAdmin)
+            {
+                var baseUrl = (_adminOptions.BaseUrl ?? string.Empty).Trim();
+                SuccessInfo = new AdminCreationSummary(baseUrl, spec.Realm, spec.ClientId, wikiUrl, endpointsUrl);
+            }
+
+            if (requiresAdminExtras)
+            {
+                var secret = await _clients.GetClientSecretAsync(spec.Realm, spec.ClientId, ct);
+                if (string.IsNullOrWhiteSpace(secret))
+                {
+                    ModelState.AddModelError(string.Empty, "Не удалось получить secret созданного клиента.");
+                    StepToShow = DetermineStepFromErrors(ModelState);
+                    return Page();
+                }
+
+                var password = GenerateSecurePassword();
+                var archiveBytes = BuildSecretArchive(spec.ClientId, secret, password);
+                var archiveName = $"{spec.ClientId}.zip";
+                var requestNumber = CreatioRequestNumber ?? string.Empty;
+                var subject = $"Пароль от архива по заявке - {requestNumber}";
+                var body = $"Добрый день пароль от архива - {password}";
+
+                try
+                {
+                    await _emailSender.SendAsync(ArchivePasswordEmail!, subject, body, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to send archive password email for {ClientId}", spec.ClientId);
+                    ModelState.AddModelError(nameof(ArchivePasswordEmail), "Не удалось отправить письмо с паролем. Попробуйте другой email или повторите позднее.");
+                    StepToShow = DetermineStepFromErrors(ModelState);
+                    return Page();
+                }
+
+                ArchiveBase64 = Convert.ToBase64String(archiveBytes);
+                ArchiveFileName = archiveName;
+            }
+
+            if (IsAdmin)
+            {
+                ModelState.Clear();
+                StepToShow = requiresAdminExtras ? 8 : 1;
+                return Page();
             }
 
             TempData["FlashOk"] = $"Клиент '{spec.ClientId}' создан (id={createdId}).";
@@ -292,5 +409,56 @@ public class CreateModel : PageModel
             StepToShow = DetermineStepFromErrors(ModelState);
             return Page();
         }
+    }
+
+    private static string GenerateSecurePassword()
+    {
+        Span<byte> buffer = stackalloc byte[24];
+        RandomNumberGenerator.Fill(buffer);
+        return Convert.ToBase64String(buffer);
+    }
+
+    private static byte[] BuildSecretArchive(string clientId, string secret, string password)
+    {
+        using var memory = new MemoryStream();
+        using (var zip = new ZipOutputStream(memory))
+        {
+            zip.SetLevel(9);
+            zip.Password = password;
+            var entry = new ZipEntry($"{clientId}.txt")
+            {
+                DateTime = DateTime.UtcNow,
+                Size = Encoding.UTF8.GetByteCount(secret)
+            };
+            zip.PutNextEntry(entry);
+            var data = Encoding.UTF8.GetBytes(secret);
+            zip.Write(data, 0, data.Length);
+            zip.CloseEntry();
+            zip.IsStreamOwner = false;
+        }
+
+        return memory.ToArray();
+    }
+
+    private string? BuildWikiUrl(string? pageId)
+    {
+        if (string.IsNullOrWhiteSpace(pageId))
+        {
+            return null;
+        }
+
+        var baseUrl = _confluenceOptions.BaseUrl?.TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return null;
+        }
+
+        var spaceKey = _confluenceOptions.SpaceKey?.Trim();
+        if (!string.IsNullOrWhiteSpace(spaceKey))
+        {
+            return $"{baseUrl}/spaces/{spaceKey}/pages/{pageId}";
+        }
+
+        return $"{baseUrl}/pages/{pageId}";
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -42,6 +42,7 @@ builder.Services.AddSingleton<ApiLogRepository>();
 builder.Services.AddSingleton<ClientWikiRepository>();
 builder.Services.AddScoped<IClientsProvider, DbClientsProvider>();
 builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection("Email"));
+builder.Services.AddScoped<ISimpleEmailSender, SimpleEmailSender>();
 builder.Services.AddScoped<IAccessRequestEmailSender, AccessRequestEmailSender>();
 var confluenceLabels = builder.Configuration.GetSection("Confluence").GetSection("Labels").Get<string[]?>();
 var confluenceOptions = ConfluenceOptions.FromConnectionString(builder.Configuration.GetConnectionString("ConnectionWiki"), confluenceLabels);

--- a/Services/SimpleEmailSender.cs
+++ b/Services/SimpleEmailSender.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using System.Net.Mail;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Assistant.Services;
+
+public interface ISimpleEmailSender
+{
+    Task SendAsync(string recipient, string subject, string body, CancellationToken cancellationToken = default);
+}
+
+public sealed class SimpleEmailSender : ISimpleEmailSender
+{
+    private readonly EmailOptions _options;
+    private readonly ILogger<SimpleEmailSender> _logger;
+
+    public SimpleEmailSender(IOptions<EmailOptions> options, ILogger<SimpleEmailSender> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SendAsync(string recipient, string subject, string body, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(recipient))
+        {
+            throw new ArgumentException("Recipient email is required.", nameof(recipient));
+        }
+
+        var host = _options.Host;
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            throw new InvalidOperationException("SMTP host is not configured.");
+        }
+
+        var fromAddress = _options.From;
+        if (string.IsNullOrWhiteSpace(fromAddress))
+        {
+            fromAddress = _options.Username;
+            if (string.IsNullOrWhiteSpace(fromAddress))
+            {
+                throw new InvalidOperationException("Sender email is not configured.");
+            }
+        }
+
+        using var message = new MailMessage
+        {
+            From = new MailAddress(fromAddress),
+            Subject = subject ?? string.Empty,
+            Body = body ?? string.Empty,
+            SubjectEncoding = Encoding.UTF8,
+            BodyEncoding = Encoding.UTF8
+        };
+
+        message.To.Add(new MailAddress(recipient.Trim()));
+
+        using var client = new SmtpClient(host, _options.Port)
+        {
+            EnableSsl = _options.EnableSsl
+        };
+
+        if (!string.IsNullOrWhiteSpace(_options.Username))
+        {
+            client.Credentials = new NetworkCredential(_options.Username, _options.Password);
+        }
+
+        try
+        {
+            await client.SendMailAsync(message, cancellationToken);
+            _logger.LogInformation("Sent email to {Recipient} with subject {Subject}.", recipient, subject);
+        }
+        catch (Exception ex) when (ex is SmtpException or InvalidOperationException or FormatException)
+        {
+            _logger.LogError(ex, "Failed to send email to {Recipient}.", recipient);
+            throw;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin-only Creatio step to the client creation wizard with request and email fields
- automatically fetch the new client secret, package it into a password-protected archive, send the password email, and show a configuration modal for admins
- introduce a reusable SMTP email sender service and wire it along with SharpZipLib for archive creation

## Testing
- `dotnet build assistant` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d598545194832dbdb838efb901181d