### PR TITLE
Fix Razor script helpers in client creation page

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -411,7 +411,7 @@
           const swService    = $('#swService');
 
           // Admin step
-          const isAdmin = @(Model.IsAdmin ? "true" : "false");
+          const isAdmin = @Model.IsAdmin.ToString().ToLowerInvariant();
           const creatioInput = $('#creatioNumber');
           const archiveEmailInput = $('#archiveEmail');
           const errCreatio = $('#errCreatio');
@@ -680,10 +680,11 @@
               loadingButton.setAttribute('data-loading', 'true');
               loadingButton.setAttribute('disabled', 'disabled');
             }
-            [btnPrev, btnNext, btnSkip].forEach(btn =>
-            {
-              if (btn) btn.setAttribute('disabled', 'disabled');
-            });
+          const navButtons = [btnPrev, btnNext, btnSkip];
+          navButtons.forEach(btn =>
+          {
+            if (btn) btn.setAttribute('disabled', 'disabled');
+          });
 
           });
 
@@ -695,18 +696,6 @@
           showStep(_start);
 
           // локальные рендер-функции уже объявлены выше
-          function renderChips(listEl, arr){
-            if (!listEl) return;
-            listEl.innerHTML = '';
-            arr.forEach((v, idx) => {
-              const span = document.createElement('span');
-              span.className = 'chip';
-              span.innerHTML = `${v} <button type="button" title="Remove">×</button>`;
-              span.querySelector('button')
-                  .addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(listEl, arr); });
-              listEl.appendChild(span);
-            });
-          }
         })();
     </script>
 


### PR DESCRIPTION
## Summary
- replace direct array literal invocation with a named constant before iteration to avoid Razor parse issues
- remove duplicated renderChips helper declaration inside the inline script block
- emit the admin flag using a lower-case boolean literal for JavaScript consistency

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a93e8de4832dbb4542f88cad93fe