### PR TITLE
Add admin-only secret distribution workflow for confidential clients

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -1,7 +1,8 @@
 ﻿@page
 @model Assistant.Pages.Clients.CreateModel
-@{
+@{ 
     ViewData["Title"] = "Create client";
+    var stepperGridClass = Model.IsAdmin ? "grid-cols-8" : "grid-cols-7";
 }
 
 <div class="space-y-5">
@@ -26,7 +27,7 @@
     <!-- Stepper -->
     <div class="kc-card md:max-w-[1000px] mx-auto">
         <div class="p-5">
-            <div class="grid grid-cols-7 gap-1">
+            <div class="grid @stepperGridClass gap-1">
                 <div class="step" id="stepHead1"><div class="dot">1</div><div class="label">Realm</div></div>
                 <div class="step" id="stepHead2"><div class="dot">2</div><div class="label">Basics</div></div>
                 <div class="step" id="stepHead3"><div class="dot">3</div><div class="label">System info</div></div>
@@ -34,6 +35,10 @@
                 <div class="step" id="stepHead5"><div class="dot">5</div><div class="label">Redirect URIs</div></div>
                 <div class="step" id="stepHead6"><div class="dot">6</div><div class="label">Local roles</div></div>
                 <div class="step" id="stepHead7"><div class="dot">7</div><div class="label">Service roles</div></div>
+                @if (Model.IsAdmin)
+                {
+                    <div class="step" id="stepHead8"><div class="dot">8</div><div class="label">Creatio</div></div>
+                }
             </div>
             <div class="mt-3 divider"></div>
         </div>
@@ -52,6 +57,8 @@
             <input type="hidden" asp-for="AppUrl" id="hidAppUrl" />
             <input type="hidden" asp-for="ServiceOwner" id="hidServiceOwner" />
             <input type="hidden" asp-for="ServiceManager" id="hidServiceManager" />
+            <input type="hidden" asp-for="CreatioRequestNumber" id="hidCreatioRequestNumber" />
+            <input type="hidden" asp-for="CreatioSecretEmail" id="hidCreatioSecretEmail" />
 
             <!-- Шаг 1: Realm -->
             <div class="space-y-4" id="step-1" data-step="1">
@@ -231,7 +238,7 @@
 
             <!-- Шаг 7: Service roles -->
             <div class="space-y-4 hidden" data-step="7">
-                <div class="text-slate-200 font-semibold text-lg">6. Service roles</div>
+                <div class="text-slate-200 font-semibold text-lg">7. Service roles</div>
                 <div class="hint">
                     Введите <b>clientId</b> (или часть) <u>или</u> фрагмент имени роли. В результатах можно
                     выбрать клиента (чтобы просмотреть все его роли) или сразу роль для добавления.
@@ -266,23 +273,83 @@
                     <div id="svcRoleList" class="grid md:grid-cols-2 gap-2"></div>
                     <div><button type="button" id="btnMoreRoles" class="btn-subtle hidden">Показать ещё</button></div>
 
-                    <div id="svcErr" class="err"></div>
-                    <div class="kc-mini">Клик по роли добавляет её в список выше. Формат: <code>clientId: roleName</code>.</div>
-                </div>
+                <div id="svcErr" class="err"></div>
+                <div class="kc-mini">Клик по роли добавляет её в список выше. Формат: <code>clientId: roleName</code>.</div>
             </div>
+        </div>
 
-            <!-- Навигация -->
-            <div class="wizard-nav mt-6">
-                <button type="button" class="btn-subtle" id="btnPrev">Back</button>
-                <div class="wizard-right">
-                    <button type="button" class="btn-subtle" id="btnSkip" style="display:none">Skip</button>
-                    <button type="button" class="btn-primary" id="btnNext">Next</button>
-                    <button type="submit" class="btn-primary" id="btnCreate" style="display:none">Create client</button>
+        @if (Model.IsAdmin)
+        {
+            <!-- Шаг 8: Creatio -->
+            <div class="space-y-4 hidden" id="step-8" data-step="8">
+                <div class="text-slate-200 font-semibold text-lg">8. Заявка Creatio</div>
+                <div class="grid md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm text-slate-400 mb-1">Номер заявки Creatio</label>
+                        <input id="creatioRequest"
+                               value="@(Model.CreatioRequestNumber ?? string.Empty)"
+                               maxlength="50"
+                               class="kc-input kc-select-dark rounded-xl px-3 py-2 text-sm w-full"
+                               placeholder="Например: CR-12345"
+                               autocomplete="off" autocapitalize="off" spellcheck="false" />
+                        <div id="errCreatioNumber" class="err">Укажите номер заявки Creatio.</div>
+                    </div>
+                    <div>
+                        <label class="block text-sm text-slate-400 mb-1">Email для отправки пароля</label>
+                        <input id="creatioEmail"
+                               value="@(Model.CreatioSecretEmail ?? string.Empty)"
+                               maxlength="100"
+                               class="kc-input kc-select-dark rounded-xl px-3 py-2 text-sm w-full"
+                               placeholder="user@example.com"
+                               autocomplete="off" autocapitalize="off" spellcheck="false" />
+                        <div id="errCreatioEmail" class="err">Укажите корректный email.</div>
+                    </div>
                 </div>
+                <div class="hint">Укажите данные только для confidential клиентов. Пароль от архива будет направлен на указанную почту.</div>
             </div>
+        }
+
+        <!-- Навигация -->
+        <div class="wizard-nav mt-6">
+            <button type="button" class="btn-subtle" id="btnPrev">Back</button>
+            <div class="wizard-right">
+                <button type="button" class="btn-subtle" id="btnSkip" style="display:none">Skip</button>
+                <button type="button" class="btn-primary" id="btnNext">Next</button>
+                <button type="submit" class="btn-primary" id="btnCreate" style="display:none">Create client</button>
+            </div>
+        </div>
         </form>
     </div>
 </div>
+
+@if (!string.IsNullOrEmpty(Model.SecretArchiveBase64) && !string.IsNullOrEmpty(Model.SecretArchiveFileName))
+{
+    <div id="secretArchiveMeta"
+         data-base64="@Model.SecretArchiveBase64"
+         data-filename="@Model.SecretArchiveFileName"
+         data-content-type="@(Model.SecretArchiveContentType ?? "application/zip")"
+         hidden></div>
+}
+
+@if (Model.ShowSuccessModal && !string.IsNullOrEmpty(Model.ModalMessage))
+{
+    <div id="creationModal" class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-4">
+        <div class="relative w-full max-w-2xl rounded-2xl bg-slate-900 p-6 shadow-2xl border border-white/10">
+            <button type="button"
+                    class="absolute top-3 right-3 text-slate-400 hover:text-slate-200"
+                    aria-label="Закрыть"
+                    data-close-modal>
+                ×
+            </button>
+            <div class="text-xl font-semibold text-slate-100 mb-4">Конфигурация создана</div>
+            <div class="rounded-xl bg-slate-950/60 border border-white/5 p-4 text-sm text-slate-200 whitespace-pre-line"
+                 id="creationModalMessage">@Model.ModalMessage</div>
+            <div class="mt-6 text-right">
+                <button type="button" class="btn-primary" data-close-modal>Закрыть</button>
+            </div>
+        </div>
+    </div>
+}
 
 @section Toasts {
     @if (!ViewContext.ViewData.ModelState.IsValid)
@@ -314,6 +381,7 @@
           // ---- DOM helpers
           const $  = (s)=>document.querySelector(s);
           const $$ = (s)=>Array.from(document.querySelectorAll(s));
+          const isAdmin = @(Model.IsAdmin ? "true" : "false");
           const idForRealm = "@Html.IdFor(m => m.Realm)";
 
           // ---- Data from server (realm → displayName)
@@ -356,6 +424,10 @@
           const ownerInput   = $('#serviceOwner');
           const managerInput = $('#serviceManager');
           const errAppName   = $('#errAppName');
+          const creatioRequestInput = $('#creatioRequest');
+          const creatioEmailInput   = $('#creatioEmail');
+          const errCreatioNumber    = $('#errCreatioNumber');
+          const errCreatioEmail     = $('#errCreatioEmail');
 
           // Redirects / Local / Service roles (чипы)
           const redirInput = $('#redirInput'), redirList = $('#redirList');
@@ -375,6 +447,8 @@
           const hidAppUrl        = $('#hidAppUrl');
           const hidServiceOwner  = $('#hidServiceOwner');
           const hidServiceManager= $('#hidServiceManager');
+          const hidCreatioNumber = $('#hidCreatioRequestNumber');
+          const hidCreatioEmail  = $('#hidCreatioSecretEmail');
 
           // ---- Chips data
           const redirs   = @Html.Raw(string.IsNullOrWhiteSpace(Model.RedirectUrisJson) ? "[]" : Model.RedirectUrisJson);
@@ -394,6 +468,7 @@
           {
             5: ()=> swStandard?.checked ?? true,
             7: ()=> swService?.checked  ?? false,
+            8: ()=> isAdmin && (swClientAuth?.checked ?? false),
           };
 
           const enabledSteps = () =>
@@ -414,11 +489,14 @@
 
           // ---- Validation
           const trim = (v)=> (v||'').trim();
+          const emailRe = /^[^@\s]+@[^@\s]+\.[^@\s]+$/i;
           function validateStep(n)
           {
             $('#errRealm')?.classList.remove('show');
             errCid?.classList.remove('show');
             errAppName?.classList.remove('show');
+            errCreatioNumber?.classList.remove('show');
+            errCreatioEmail?.classList.remove('show');
 
             if (n===1)
             {
@@ -431,6 +509,23 @@
             if (n===3)
             {
               if (!trim(appNameInput?.value)){ errAppName?.classList.add('show'); appNameInput?.focus(); return false; }
+            }
+            if (n===8 && isAdmin && (swClientAuth?.checked ?? false))
+            {
+              if (!trim(creatioRequestInput?.value))
+              {
+                errCreatioNumber?.classList.add('show');
+                creatioRequestInput?.focus();
+                return false;
+              }
+
+              const emailValue = trim(creatioEmailInput?.value);
+              if (!emailValue || !emailRe.test(emailValue))
+              {
+                errCreatioEmail?.classList.add('show');
+                creatioEmailInput?.focus();
+                return false;
+              }
             }
             return true;
           }
@@ -553,6 +648,12 @@
               if (!validateStep(3)) return showStep(3);
             }
 
+            if (isAdmin && (swClientAuth?.checked ?? false) && !validateStep(8))
+            {
+              e.preventDefault();
+              return showStep(8);
+            }
+
             const suffix   = trim(cidInput?.value);
             const clientId = 'app-bank-' + suffix;
 
@@ -570,6 +671,8 @@
             hidAppUrl.value         = trim(appUrlInput?.value);
             hidServiceOwner.value   = trim(ownerInput?.value);
             hidServiceManager.value = trim(managerInput?.value);
+            if (hidCreatioNumber) hidCreatioNumber.value = trim(creatioRequestInput?.value);
+            if (hidCreatioEmail)  hidCreatioEmail.value  = trim(creatioEmailInput?.value);
 
             const submitter = (e.submitter instanceof HTMLElement) ? e.submitter : null;
             const loadingButton = submitter ?? btnCreate;
@@ -603,6 +706,55 @@
               span.querySelector('button')
                   .addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(listEl, arr); });
               listEl.appendChild(span);
+            });
+          }
+        })();
+    </script>
+
+    <script data-soft-nav>
+        (() => {
+          const archiveMeta = document.getElementById('secretArchiveMeta');
+          if (archiveMeta)
+          {
+            const base64 = archiveMeta.getAttribute('data-base64') || '';
+            const fileName = archiveMeta.getAttribute('data-filename') || 'client-secret.zip';
+            const contentType = archiveMeta.getAttribute('data-content-type') || 'application/zip';
+
+            if (base64)
+            {
+              try
+              {
+                const binary = atob(base64);
+                const bytes = new Uint8Array(binary.length);
+                for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+                const blob = new Blob([bytes], { type: contentType });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = fileName;
+                a.style.display = 'none';
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                setTimeout(() => URL.revokeObjectURL(url), 2000);
+              }
+              catch (err)
+              {
+                console.error('Не удалось подготовить скачивание архива', err);
+              }
+            }
+
+            archiveMeta.remove();
+          }
+
+          const modal = document.getElementById('creationModal');
+          if (modal)
+          {
+            const close = () => modal.remove();
+            modal.querySelectorAll('[data-close-modal]')
+                 .forEach(btn => btn.addEventListener('click', close));
+            modal.addEventListener('click', (evt) => {
+              if (evt.target === modal) close();
             });
           }
         })();

--- a/Program.cs
+++ b/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddSingleton<ClientWikiRepository>();
 builder.Services.AddScoped<IClientsProvider, DbClientsProvider>();
 builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection("Email"));
 builder.Services.AddScoped<IAccessRequestEmailSender, AccessRequestEmailSender>();
+builder.Services.AddScoped<ClientSecretDistributionService>();
 var confluenceLabels = builder.Configuration.GetSection("Confluence").GetSection("Labels").Get<string[]?>();
 var confluenceOptions = ConfluenceOptions.FromConnectionString(builder.Configuration.GetConnectionString("ConnectionWiki"), confluenceLabels);
 builder.Services.AddSingleton(confluenceOptions);

--- a/Services/ClientSecretDistributionService.cs
+++ b/Services/ClientSecretDistributionService.cs
@@ -1,0 +1,187 @@
+using System.IO;
+using System.Net;
+using System.Net.Mail;
+using System.Security.Cryptography;
+using System.Text;
+using ICSharpCode.SharpZipLib.Zip;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Assistant.Services;
+
+public sealed record ClientSecretArchiveResult(byte[] Content, string FileName, string ContentType);
+
+public sealed class ClientSecretDistributionService
+{
+    private static readonly char[] UpperChars = "ABCDEFGHJKLMNPQRSTUVWXYZ".ToCharArray();
+    private static readonly char[] LowerChars = "abcdefghijkmnopqrstuvwxyz".ToCharArray();
+    private static readonly char[] DigitChars = "23456789".ToCharArray();
+    private static readonly char[] SymbolChars = "!@$?*-_#".ToCharArray();
+    private static readonly char[] PasswordChars =
+        "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@$?*-_#".ToCharArray();
+
+    private readonly EmailOptions _options;
+    private readonly ILogger<ClientSecretDistributionService> _logger;
+
+    public ClientSecretDistributionService(IOptions<EmailOptions> options, ILogger<ClientSecretDistributionService> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<ClientSecretArchiveResult> CreateAsync(
+        string clientId,
+        string secret,
+        string recipientEmail,
+        string requestNumber,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(secret);
+        ArgumentException.ThrowIfNullOrWhiteSpace(recipientEmail);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestNumber);
+
+        var safeClientId = GetSafeFileName(clientId.Trim());
+        var password = GeneratePassword();
+        var archiveBytes = CreateArchive(safeClientId, secret.Trim(), password);
+
+        await SendEmailAsync(safeClientId, recipientEmail.Trim(), requestNumber.Trim(), password, cancellationToken);
+
+        var archiveFileName = safeClientId + ".zip";
+        return new ClientSecretArchiveResult(archiveBytes, archiveFileName, "application/zip");
+    }
+
+    private async Task SendEmailAsync(
+        string clientId,
+        string recipientEmail,
+        string requestNumber,
+        string password,
+        CancellationToken cancellationToken)
+    {
+        var host = _options.Host;
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            throw new InvalidOperationException("SMTP host is not configured.");
+        }
+
+        var fromAddress = _options.From;
+        if (string.IsNullOrWhiteSpace(fromAddress))
+        {
+            fromAddress = _options.Username;
+            if (string.IsNullOrWhiteSpace(fromAddress))
+            {
+                throw new InvalidOperationException("Sender email is not configured.");
+            }
+        }
+
+        using var message = new MailMessage
+        {
+            From = new MailAddress(fromAddress),
+            Subject = $"Пароль от архива по заявке - {requestNumber}",
+            Body = $"Добрый день пароль от архива - {password}",
+            BodyEncoding = Encoding.UTF8,
+            SubjectEncoding = Encoding.UTF8
+        };
+
+        message.To.Add(new MailAddress(recipientEmail));
+
+        using var client = new SmtpClient(host, _options.Port)
+        {
+            EnableSsl = _options.EnableSsl
+        };
+
+        if (!string.IsNullOrWhiteSpace(_options.Username))
+        {
+            client.Credentials = new NetworkCredential(_options.Username, _options.Password);
+        }
+
+        try
+        {
+            await client.SendMailAsync(message, cancellationToken);
+            _logger.LogInformation(
+                "Sent archive password for client {ClientId} to {Recipient} (request {RequestNumber}).",
+                clientId,
+                recipientEmail,
+                requestNumber);
+        }
+        catch (Exception ex) when (ex is SmtpException or InvalidOperationException or FormatException)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to send archive password for client {ClientId} to {Recipient} (request {RequestNumber}).",
+                clientId,
+                recipientEmail,
+                requestNumber);
+            throw;
+        }
+    }
+
+    private static byte[] CreateArchive(string safeClientId, string secret, string password)
+    {
+        using var buffer = new MemoryStream();
+        using (var zip = new ZipOutputStream(buffer))
+        {
+            zip.SetLevel(9);
+            zip.Password = password;
+            zip.IsStreamOwner = false;
+
+            var entry = new ZipEntry(safeClientId + ".txt")
+            {
+                AESKeySize = 256,
+                DateTime = DateTime.UtcNow
+            };
+
+            zip.PutNextEntry(entry);
+            var content = Encoding.UTF8.GetBytes(secret + Environment.NewLine);
+            zip.Write(content, 0, content.Length);
+            zip.CloseEntry();
+            zip.Finish();
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static string GetSafeFileName(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "client";
+        }
+
+        var builder = new StringBuilder(value.Length);
+        var invalid = Path.GetInvalidFileNameChars();
+        foreach (var ch in value)
+        {
+            builder.Append(Array.IndexOf(invalid, ch) >= 0 ? '_' : ch);
+        }
+
+        return builder.Length == 0 ? "client" : builder.ToString();
+    }
+
+    private static string GeneratePassword(int length = 16)
+    {
+        length = Math.Max(length, 12);
+
+        Span<char> chars = stackalloc char[length];
+        Span<byte> buffer = stackalloc byte[length];
+        RandomNumberGenerator.Fill(buffer);
+
+        for (var i = 0; i < length; i++)
+        {
+            chars[i] = PasswordChars[buffer[i] % PasswordChars.Length];
+        }
+
+        chars[0] = UpperChars[buffer[0] % UpperChars.Length];
+        chars[1] = LowerChars[buffer[1] % LowerChars.Length];
+        chars[2] = DigitChars[buffer[2] % DigitChars.Length];
+        chars[3] = SymbolChars[buffer[3] % SymbolChars.Length];
+
+        for (var i = length - 1; i > 0; i--)
+        {
+            var j = buffer[i] % (i + 1);
+            (chars[i], chars[j]) = (chars[j], chars[i]);
+        }
+
+        return new string(chars);
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin-only Creatio step to the client creation wizard with request number and email inputs for confidential clients
- prepare a password-protected client secret archive after creation, trigger the download for admins, and mail the archive password using configuration
- display an informational modal for admins after client creation with realm details and Confluence link using a new secret distribution service

## Testing
- dotnet build *(fails: dotnet command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5adaf70f8832d8109bd0f75440fc7