### PR TITLE
Fix creation modal overlay and correct success message URLs

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -333,8 +333,8 @@
 
 @if (Model.ShowSuccessModal && !string.IsNullOrEmpty(Model.ModalMessage))
 {
-    <div id="creationModal" class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-4">
-        <div class="relative w-full max-w-2xl rounded-2xl bg-slate-900 p-6 shadow-2xl border border-white/10">
+    <div id="creationModal" class="kc-modal-overlay fixed inset-0 z-50 flex items-center justify-center px-4">
+        <div class="kc-modal-panel relative w-full max-w-2xl rounded-2xl p-6 shadow-2xl border border-white/10">
             <button type="button"
                     class="absolute top-3 right-3 text-slate-400 hover:text-slate-200"
                     aria-label="Закрыть"
@@ -342,7 +342,7 @@
                 ×
             </button>
             <div class="text-xl font-semibold text-slate-100 mb-4">Конфигурация создана</div>
-            <div class="rounded-xl bg-slate-950/60 border border-white/5 p-4 text-sm text-slate-200 whitespace-pre-line"
+            <div class="rounded-xl bg-slate-950/80 border border-white/10 p-4 text-sm text-slate-200 whitespace-pre-line"
                  id="creationModalMessage">@Model.ModalMessage</div>
             <div class="mt-6 text-right">
                 <button type="button" class="btn-primary" data-close-modal>Закрыть</button>
@@ -750,12 +750,18 @@
           const modal = document.getElementById('creationModal');
           if (modal)
           {
+            const active = document.activeElement;
+            if (active instanceof HTMLElement) active.blur();
+
             const close = () => modal.remove();
             modal.querySelectorAll('[data-close-modal]')
                  .forEach(btn => btn.addEventListener('click', close));
             modal.addEventListener('click', (evt) => {
               if (evt.target === modal) close();
             });
+
+            const primaryClose = modal.querySelector('.btn-primary[data-close-modal]');
+            if (primaryClose instanceof HTMLElement) primaryClose.focus();
           }
         })();
     </script>

--- a/Pages/Clients/Create.cshtml.cs
+++ b/Pages/Clients/Create.cshtml.cs
@@ -431,10 +431,10 @@ public class CreateModel : PageModel
         var sb = new StringBuilder();
         sb.AppendLine("Создана конфигурация в TEST среде");
 
-        var issuer = ComposeRealmIssuer(spec.Realm);
-        if (!string.IsNullOrWhiteSpace(issuer))
+        var baseUrl = ComposeRealmBaseUrl(spec.Realm);
+        if (!string.IsNullOrWhiteSpace(baseUrl))
         {
-            sb.AppendLine($"Base URL: {issuer}");
+            sb.AppendLine($"Base URL: {baseUrl}");
         }
 
         sb.AppendLine($"Realm: {spec.Realm}");
@@ -455,7 +455,7 @@ public class CreateModel : PageModel
         return sb.ToString().TrimEnd();
     }
 
-    private string ComposeRealmIssuer(string realm)
+    private string ComposeRealmBaseUrl(string realm)
     {
         if (string.IsNullOrWhiteSpace(realm))
         {
@@ -464,21 +464,29 @@ public class CreateModel : PageModel
 
         if (_realmLinks.TryGetRealmLink(realm, out var mapped) && !string.IsNullOrWhiteSpace(mapped))
         {
-            var normalized = mapped.TrimEnd('/');
-            return normalized.Contains("/realms/", StringComparison.OrdinalIgnoreCase)
-                ? normalized
-                : $"{normalized}/realms/{realm}";
+            return mapped.TrimEnd('/');
         }
 
         if (!string.IsNullOrWhiteSpace(_kcBaseUrl))
         {
-            var normalized = _kcBaseUrl.TrimEnd('/');
-            return normalized.Contains("/realms/", StringComparison.OrdinalIgnoreCase)
-                ? normalized
-                : $"{normalized}/realms/{realm}";
+            return _kcBaseUrl.TrimEnd('/');
         }
 
-        return realm;
+        return string.Empty;
+    }
+
+    private string ComposeRealmIssuer(string realm)
+    {
+        var baseUrl = ComposeRealmBaseUrl(realm);
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return string.Empty;
+        }
+
+        var normalized = baseUrl.TrimEnd('/');
+        return normalized.Contains("/realms/", StringComparison.OrdinalIgnoreCase)
+            ? normalized
+            : $"{normalized}/realms/{realm}";
     }
 
     private string ComposeEndpointsUrl(string realm)

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -73,6 +73,20 @@
     padding-top: 0.5rem;
     padding-bottom: 0.65rem;
 }
+
+/* ===== Modal ===== */
+.kc-modal-overlay {
+    background: rgba(3, 7, 18, .88);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.kc-modal-panel {
+    background: linear-gradient(180deg, rgba(9, 13, 22, .97), rgba(5, 8, 15, .98));
+    border: 1px solid rgba(255, 255, 255, .08);
+    box-shadow: 0 28px 60px rgba(0, 0, 0, .6);
+}
+
 /* ===== Cards / Panels ===== */
 .kc-card {
     position: relative;


### PR DESCRIPTION
## Summary
- darken and restyle the creation success modal overlay to remove the highlight underneath
- blur the previously focused element and focus the modal button when the modal opens to avoid lingering outlines
- show the Keycloak base URL and derived endpoints using the configured realm mappings

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c95a700c832d9885540f15db89e1