### PR TITLE
Remove modal backdrop effects on client creation page

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -333,7 +333,7 @@
 
 @if (Model.ShowSuccessModal && !string.IsNullOrEmpty(Model.ModalMessage))
 {
-    <div id="creationModal" class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-4">
+    <div id="creationModal" class="fixed inset-0 z-50 flex items-center justify-center px-4">
         <div class="relative w-full max-w-2xl rounded-2xl bg-slate-900 p-6 shadow-2xl border border-white/10">
             <button type="button"
                     class="absolute top-3 right-3 text-slate-400 hover:text-slate-200"


### PR DESCRIPTION
## Summary
- remove the darkened backdrop from the client creation success modal so the page behind it no longer shows blur or other effects

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cccbd8e8832da4e16aefb98cd8e1