### PR TITLE
Fix Keycloak issuer URL selection

### DIFF
--- a/Pages/Clients/Create.cshtml.cs
+++ b/Pages/Clients/Create.cshtml.cs
@@ -462,23 +462,25 @@ public class CreateModel : PageModel
             return string.Empty;
         }
 
-        if (_realmLinks.TryGetRealmLink(realm, out var mapped) && !string.IsNullOrWhiteSpace(mapped))
-        {
-            var normalized = mapped.TrimEnd('/');
-            return normalized.Contains("/realms/", StringComparison.OrdinalIgnoreCase)
-                ? normalized
-                : $"{normalized}/realms/{realm}";
-        }
-
         if (!string.IsNullOrWhiteSpace(_kcBaseUrl))
         {
-            var normalized = _kcBaseUrl.TrimEnd('/');
-            return normalized.Contains("/realms/", StringComparison.OrdinalIgnoreCase)
-                ? normalized
-                : $"{normalized}/realms/{realm}";
+            return NormalizeIssuer(_kcBaseUrl, realm);
+        }
+
+        if (_realmLinks.TryGetRealmLink(realm, out var mapped) && !string.IsNullOrWhiteSpace(mapped))
+        {
+            return NormalizeIssuer(mapped, realm);
         }
 
         return realm;
+    }
+
+    private static string NormalizeIssuer(string baseUrl, string realm)
+    {
+        var normalized = baseUrl.TrimEnd('/');
+        return normalized.Contains("/realms/", StringComparison.OrdinalIgnoreCase)
+            ? normalized
+            : $"{normalized}/realms/{realm}";
     }
 
     private string ComposeEndpointsUrl(string realm)


### PR DESCRIPTION
## Summary
- ensure the Keycloak base URL from configuration is used when composing modal links
- reuse a helper to normalize issuer URLs consistently

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d123362c832d9f7c98f5d7f5353b