### PR TITLE
Make Confluence link clickable in flash messages

### DIFF
--- a/Pages/Admin/ServiceRoleExclusions.cshtml
+++ b/Pages/Admin/ServiceRoleExclusions.cshtml
@@ -225,7 +225,7 @@
         <div class="kc-toast kc-toast-success" id="flashToastOk" role="alert">
             <div class="kc-toast-icon">✓</div>
             <div class="kc-toast-body">
-                <div class="kc-toast-title">@ok</div>
+                <div class="kc-toast-title">@Html.Raw(ok)</div>
             </div>
             <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
         </div>

--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -393,7 +393,7 @@
         <div class="kc-toast kc-toast-success" id="flashToastOk" role="alert">
             <div class="kc-toast-icon">✓</div>
             <div class="kc-toast-body">
-                <div class="kc-toast-title">@ok</div>
+                <div class="kc-toast-title">@Html.Raw(ok)</div>
             </div>
             <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
         </div>

--- a/Pages/Clients/Create.cshtml.cs
+++ b/Pages/Clients/Create.cshtml.cs
@@ -335,9 +335,10 @@ public class CreateModel : PageModel
                 }
             }
 
+            var flashMessage = BuildClientCreatedFlashMessage(wikiLink);
             if (!IsAdmin)
             {
-                TempData["FlashOk"] = $"Клиент '{spec.ClientId}' создан (id={createdId}).";
+                TempData["FlashOk"] = flashMessage;
                 return RedirectToPage("/Index");
             }
 
@@ -411,7 +412,7 @@ public class CreateModel : PageModel
                 ModelState.AddModelError(string.Empty, distributionError);
             }
 
-            TempData["FlashOk"] = $"Клиент '{spec.ClientId}' создан (id={createdId}).";
+            TempData["FlashOk"] = flashMessage;
             return Page();
         }
         catch (Exception ex)
@@ -425,6 +426,18 @@ public class CreateModel : PageModel
 
     private static bool IsValidEmailAddress(string? value)
         => !string.IsNullOrWhiteSpace(value) && MailAddress.TryCreate(value, out _);
+
+    private string BuildClientCreatedFlashMessage(string? wikiLink)
+    {
+        var message = "Клиент успешно создан.";
+        if (!string.IsNullOrWhiteSpace(wikiLink))
+        {
+            var encodedLink = System.Net.WebUtility.HtmlEncode(wikiLink);
+            message += $" <a href=\"{encodedLink}\" target=\"_blank\" rel=\"noopener noreferrer\">Открыть страницу в Confluence</a>.";
+        }
+
+        return message;
+    }
 
     private string BuildModalMessage(NewClientSpec spec, string? wikiLink, string secretLine)
     {

--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -469,7 +469,7 @@
         <div class="kc-toast kc-toast-success" id="flashToastOk" role="alert">
             <div class="kc-toast-icon">✓</div>
             <div class="kc-toast-body">
-                <div class="kc-toast-title">@ok</div>
+                <div class="kc-toast-title">@Html.Raw(ok)</div>
             </div>
             <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
         </div>

--- a/Pages/Clients/Details.cshtml.cs
+++ b/Pages/Clients/Details.cshtml.cs
@@ -20,6 +20,7 @@ public class DetailsModel : PageModel
     private readonly ConfluenceWikiService _wiki;
     private readonly ClientWikiRepository _wikiPages;
     private readonly ILogger<DetailsModel> _logger;
+    private readonly ConfluenceOptions _confluenceOptions;
 
     public DetailsModel(
         ClientsService clients,
@@ -27,6 +28,7 @@ public class DetailsModel : PageModel
         EventsService events,
         ConfluenceWikiService wiki,
         ClientWikiRepository wikiPages,
+        ConfluenceOptions confluenceOptions,
         ILogger<DetailsModel> logger)
     {
         _clients = clients;
@@ -34,6 +36,7 @@ public class DetailsModel : PageModel
         _events = events;
         _wiki = wiki;
         _wikiPages = wikiPages;
+        _confluenceOptions = confluenceOptions;
         _logger = logger;
     }
 
@@ -135,11 +138,15 @@ public class DetailsModel : PageModel
             return RedirectToPage(new { realm = Realm, clientId = ClientId, returnUrl = ReturnUrl });
         }
 
+        string? wikiLink = null;
+
         try
         {
             var wikiInfo = await _wikiPages.GetAsync(spec.Realm, spec.CurrentClientId, ct);
             if (wikiInfo is not null)
             {
+                wikiLink = BuildConfluenceLink(wikiInfo.PageId);
+
                 var payload = new ConfluenceWikiService.ClientWikiPayload(
                     Realm: spec.Realm,
                     ClientId: spec.ClientId,
@@ -165,6 +172,7 @@ public class DetailsModel : PageModel
 
                     var infoToPersist = wikiInfo with { Realm = spec.Realm, ClientId = spec.ClientId };
                     await _wikiPages.SetAsync(infoToPersist, ct);
+                    wikiLink = BuildConfluenceLink(infoToPersist.PageId);
                 }
             }
         }
@@ -173,7 +181,7 @@ public class DetailsModel : PageModel
             _logger.LogError(ex, "Failed to update Confluence wiki page for {ClientId}", spec.ClientId);
         }
 
-        TempData["FlashOk"] = "Клиент успешно обновлён.";
+        TempData["FlashOk"] = BuildClientUpdatedFlashMessage(wikiLink);
         return RedirectToPage(new { realm = Realm, clientId = newId, returnUrl = ReturnUrl });
     }
 
@@ -216,6 +224,34 @@ public class DetailsModel : PageModel
 
     public async Task<IActionResult> OnGetClientRolesAsync(string realm, string id, int first = 0, int max = 50, string? q = null, CancellationToken ct = default)
         => new JsonResult(await _clients.GetClientRolesAsync(realm, id, first, max, q, ct));
+
+    private string BuildClientUpdatedFlashMessage(string? wikiLink)
+    {
+        var message = "Клиент успешно обновлён.";
+        if (!string.IsNullOrWhiteSpace(wikiLink))
+        {
+            var encodedLink = System.Net.WebUtility.HtmlEncode(wikiLink);
+            message += $" <a href=\"{encodedLink}\" target=\"_blank\" rel=\"noopener noreferrer\">Открыть страницу в Confluence</a>.";
+        }
+
+        return message;
+    }
+
+    private string? BuildConfluenceLink(string? pageId)
+    {
+        if (string.IsNullOrWhiteSpace(pageId))
+        {
+            return null;
+        }
+
+        var baseUrl = _confluenceOptions.BaseUrl;
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return null;
+        }
+
+        return $"{baseUrl.TrimEnd('/')}/pages/{pageId}";
+    }
 
     public async Task<IActionResult> OnGetGenerateTokenAsync(
         string realm,

--- a/Pages/Clients/Search.cshtml
+++ b/Pages/Clients/Search.cshtml
@@ -61,7 +61,7 @@
         <div class="kc-toast kc-toast-success" id="flashToast" role="alert">
             <div class="kc-toast-icon">✓</div>
             <div class="kc-toast-body">
-                <div class="kc-toast-title">@flash</div>
+                <div class="kc-toast-title">@Html.Raw(flash)</div>
             </div>
             <button type="button" class="kc-toast-close" aria-label="Закрыть"
                     onclick="this.closest('.kc-toast').remove()">×</button>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -71,7 +71,7 @@
         <div class="kc-toast kc-toast-success" id="flashToast" role="alert">
             <div class="kc-toast-icon">✓</div>
             <div class="kc-toast-body">
-                <div class="kc-toast-title">@flash</div>
+                <div class="kc-toast-title">@Html.Raw(flash)</div>
             </div>
             <button type="button" class="kc-toast-close" aria-label="Закрыть"
                     onclick="this.closest('.kc-toast').remove()">×</button>


### PR DESCRIPTION
## Summary
- drop client identifiers from the success notifications after creating or updating a client and append an HTML link to the Confluence page when it exists
- render the success toast content as raw HTML so the Confluence link remains clickable across relevant pages

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d4e456c4832d81c2ebe05df2dc26