### PR TITLE
Refactor email services and centralize admin URL building

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -42,6 +42,7 @@ builder.Services.AddSingleton<ApiLogRepository>();
 builder.Services.AddSingleton<ClientWikiRepository>();
 builder.Services.AddScoped<IClientsProvider, DbClientsProvider>();
 builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection("Email"));
+builder.Services.AddSingleton<EmailClientFactory>();
 builder.Services.AddScoped<IAccessRequestEmailSender, AccessRequestEmailSender>();
 builder.Services.AddScoped<ClientSecretDistributionService>();
 var confluenceLabels = builder.Configuration.GetSection("Confluence").GetSection("Labels").Get<string[]?>();

--- a/Services/EmailClientFactory.cs
+++ b/Services/EmailClientFactory.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net;
+using System.Net.Mail;
+using Microsoft.Extensions.Options;
+
+namespace Assistant.Services;
+
+public sealed class EmailClientFactory
+{
+    private readonly EmailOptions _options;
+
+    public EmailClientFactory(IOptions<EmailOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public MailAddress CreateSenderAddress()
+    {
+        var from = string.IsNullOrWhiteSpace(_options.From) ? _options.Username : _options.From;
+        if (string.IsNullOrWhiteSpace(from))
+        {
+            throw new InvalidOperationException("Sender email is not configured.");
+        }
+
+        return new MailAddress(from);
+    }
+
+    public SmtpClient CreateClient()
+    {
+        if (string.IsNullOrWhiteSpace(_options.Host))
+        {
+            throw new InvalidOperationException("SMTP host is not configured.");
+        }
+
+        var client = new SmtpClient(_options.Host, _options.Port)
+        {
+            EnableSsl = _options.EnableSsl
+        };
+
+        if (!string.IsNullOrWhiteSpace(_options.Username))
+        {
+            client.Credentials = new NetworkCredential(_options.Username, _options.Password);
+        }
+
+        return client;
+    }
+
+    public string GetSupportRecipient()
+    {
+        if (string.IsNullOrWhiteSpace(_options.SupportRecipient))
+        {
+            throw new InvalidOperationException("Support recipient email is not configured.");
+        }
+
+        return _options.SupportRecipient;
+    }
+}


### PR DESCRIPTION
## Summary
- add an EmailClientFactory to validate configuration and produce ready-to-use SMTP clients
- refactor AccessRequestEmailSender and ClientSecretDistributionService to use the shared factory
- centralize construction of Keycloak admin URLs inside ClientsService to eliminate duplication
- register the new factory in DI so callers receive the shared infrastructure service

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dca2f71c832d945b2b71da03dca5