### PR TITLE
Remove admin flash notification after client creation

### DIFF
--- a/Pages/Clients/Create.cshtml.cs
+++ b/Pages/Clients/Create.cshtml.cs
@@ -409,7 +409,6 @@ public class CreateModel : PageModel
                 ModelState.AddModelError(string.Empty, distributionError);
             }
 
-            TempData["FlashOk"] = flashMessage;
             return Page();
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- remove the success flash notification when creating a client in admin mode so only the modal is shown

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6df4c6dfc832d82413a8acf932a91