### PR TITLE
Run inline page scripts on initial load

### DIFF
--- a/wwwroot/js/soft-navigation/index.js
+++ b/wwwroot/js/soft-navigation/index.js
@@ -25,6 +25,12 @@ if (!root || !app) {
 appVisibility.setApp(app);
 appVisibility.show();
 
+executeSoftScripts(app);
+refreshToasts(document, toastsHost);
+if (scriptHost) {
+    executeSoftScripts(scriptHost);
+}
+
 function beginPending() { }
 function endPending() { }
 


### PR DESCRIPTION
## Summary
- ensure the soft navigation bootstrap executes inline scripts and toast/scripts sections on the initial page render so filters and transitions stay active

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7da9ec690832da23151383a54cefc