### PR TITLE
Improve scroll restoration timing

### DIFF
--- a/wwwroot/js/soft-navigation.js
+++ b/wwwroot/js/soft-navigation.js
@@ -414,8 +414,12 @@
             x: Math.max(0, Math.round(position && typeof position.x === 'number' ? position.x : window.scrollX)),
             y: Math.max(0, Math.round(position && typeof position.y === 'number' ? position.y : window.scrollY))
         };
+        const previous = scrollPositions.get(url);
         scrollPositions.set(url, normalized);
         if (!sessionStorageAvailable) {
+            return;
+        }
+        if (previous && previous.x === normalized.x && previous.y === normalized.y) {
             return;
         }
         try {
@@ -465,10 +469,17 @@
             return;
         }
         if (options && options.scroll === false) {
-            if (!restoreScrollPosition(finalUrl)) {
-                window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+            const restore = () => {
+                if (!restoreScrollPosition(finalUrl)) {
+                    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+                }
+                storeScrollPosition(finalUrl);
+            };
+            if (typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(restore);
+            } else {
+                restore();
             }
-            storeScrollPosition(finalUrl);
             return;
         }
 


### PR DESCRIPTION
## Summary
- avoid redundant sessionStorage writes when scroll position has not changed
- restore scroll position after popstate inside requestAnimationFrame to prevent visual jumps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80c8c8a58832daaa92199e618519e