### PR TITLE
Fix soft navigation layout response and header comparison

### DIFF
--- a/Pages/Shared/_SoftNavLayout.cshtml
+++ b/Pages/Shared/_SoftNavLayout.cshtml
@@ -1,0 +1,42 @@
+@using System.Collections.Generic
+@using System.Text.Encodings.Web
+@using System.Text.Json
+@using Microsoft.AspNetCore.Html
+@{
+    ViewContext.HttpContext.Response.ContentType = "application/json";
+
+    string? ToHtml(IHtmlContent? content)
+    {
+        if (content is null)
+        {
+            return string.Empty;
+        }
+
+        using var writer = new System.IO.StringWriter();
+        content.WriteTo(writer, HtmlEncoder.Default);
+        return writer.ToString();
+    }
+
+    var fragments = new List<object>();
+    var bodyContent = RenderBody();
+    fragments.Add(new { target = "#app", html = ToHtml(bodyContent), mode = "inner" });
+
+    var toastsContent = RenderSection("Toasts", required: false);
+    fragments.Add(new { target = "#toastsHost", html = ToHtml(toastsContent), mode = "inner" });
+
+    var scriptsContent = RenderSection("Scripts", required: false);
+    fragments.Add(new { target = "#pageScripts", html = ToHtml(scriptsContent), mode = "inner" });
+
+    var payload = new
+    {
+        title = ViewData["Title"]?.ToString() ?? "Assistant",
+        fragments
+    };
+
+    var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        WriteIndented = false
+    });
+}
+@Html.Raw(json)

--- a/Pages/_ViewStart.cshtml
+++ b/Pages/_ViewStart.cshtml
@@ -1,3 +1,5 @@
-﻿@{
-    Layout = "_Layout";
+@{
+    var softNavHeader = Context?.Request?.Headers["X-Soft-Nav"];
+    var softNavRequested = string.Equals(softNavHeader.ToString(), "1", System.StringComparison.Ordinal);
+    Layout = softNavRequested ? "_SoftNavLayout" : "_Layout";
 }


### PR DESCRIPTION
## Summary
- set the soft-navigation layout response content type through ViewContext to ensure compilation
- read the soft navigation request header safely before comparing to the flag value

## Testing
- not run (environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_68d8346f6078832db0d6aa40fdc06952