### PR TITLE
Refine app visibility animations

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -11,6 +11,7 @@
     <!-- Tailwind для прототипа -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="~/css/kc.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/app-animations.css" asp-append-version="true" />
 
     @RenderSection("Head", required: false)
 </head>
@@ -83,7 +84,7 @@
                     </div>
                 </aside>
             }
-            <main id="app" class="flex-1">
+            <main id="app" class="flex-1 app-visibility app-visible">
                 @RenderBody()
             </main>
         </div>

--- a/wwwroot/css/app-animations.css
+++ b/wwwroot/css/app-animations.css
@@ -1,0 +1,58 @@
+:root {
+    --app-visibility-show-duration: 460ms;
+    --app-visibility-hide-duration: 360ms;
+    --app-visibility-show-easing: cubic-bezier(0.33, 1, 0.68, 1);
+    --app-visibility-hide-easing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.app-visibility {
+    opacity: 0;
+    transform: translateY(12px);
+}
+
+.app-visibility.app-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.app-visibility.app-animating {
+    will-change: opacity, transform;
+}
+
+.app-visibility.app-animating.app-showing {
+    animation: app-visibility-show var(--app-visibility-show-duration) var(--app-visibility-show-easing) both;
+}
+
+.app-visibility.app-animating.app-hiding {
+    animation: app-visibility-hide var(--app-visibility-hide-duration) var(--app-visibility-hide-easing) both;
+}
+
+@keyframes app-visibility-show {
+    0% {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    70% {
+        opacity: 0.85;
+        transform: translateY(-4px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes app-visibility-hide {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    35% {
+        opacity: 0.85;
+        transform: translateY(6px);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+}


### PR DESCRIPTION
## Summary
- move the app shell visibility transitions into CSS keyframes and utility classes
- refactor the animation controller to toggle classes, track active animations, and react to prefers-reduced-motion changes
- register the new stylesheet in the layout and initialize the app container with the visibility utilities

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d839991578832d88bc653f23ebef31