### PR TITLE
Smooth app shell transitions

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -11,6 +11,7 @@
     <!-- Tailwind для прототипа -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="~/css/kc.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/app-animations.css" asp-append-version="true" />
 
     @RenderSection("Head", required: false)
 </head>
@@ -83,7 +84,7 @@
                     </div>
                 </aside>
             }
-            <main id="app" class="flex-1">
+            <main id="app" class="flex-1 app-visibility app-visible">
                 @RenderBody()
             </main>
         </div>

--- a/wwwroot/css/app-animations.css
+++ b/wwwroot/css/app-animations.css
@@ -1,0 +1,50 @@
+:root {
+    --app-visibility-show-duration: 260ms;
+    --app-visibility-hide-duration: 220ms;
+    --app-visibility-show-easing: cubic-bezier(0.22, 1, 0.36, 1);
+    --app-visibility-hide-easing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.app-visibility {
+    opacity: 0;
+    transform: translate3d(0, 6px, 0);
+}
+
+.app-visibility.app-visible {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+}
+
+.app-visibility.app-animating {
+    will-change: opacity, transform;
+}
+
+.app-visibility.app-animating.app-showing {
+    animation: app-visibility-show var(--app-visibility-show-duration) var(--app-visibility-show-easing) both;
+}
+
+.app-visibility.app-animating.app-hiding {
+    animation: app-visibility-hide var(--app-visibility-hide-duration) var(--app-visibility-hide-easing) both;
+}
+
+@keyframes app-visibility-show {
+    0% {
+        opacity: 0;
+        transform: translate3d(0, 6px, 0);
+    }
+    100% {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@keyframes app-visibility-hide {
+    0% {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+    100% {
+        opacity: 0;
+        transform: translate3d(0, 6px, 0);
+    }
+}

--- a/wwwroot/js/animations.js
+++ b/wwwroot/js/animations.js
@@ -1,6 +1,60 @@
 import { waitForTransition } from './transitions.js';
 
 const animationStates = new WeakMap();
+const activeAnimationStates = new Set();
+
+const CLASSNAMES = {
+    base: 'app-visibility',
+    visible: 'app-visible',
+    animating: 'app-animating',
+    showing: 'app-showing',
+    hiding: 'app-hiding'
+};
+
+const PREFERS_REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+const motionPreference = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia(PREFERS_REDUCED_MOTION_QUERY)
+    : null;
+
+function onMotionPreferenceChange(event) {
+    if (!event.matches) {
+        return;
+    }
+    activeAnimationStates.forEach(state => {
+        try {
+            state.finish();
+        } catch (_) {
+            // Ignore finish errors.
+        }
+    });
+}
+
+if (motionPreference && typeof motionPreference.addEventListener === 'function') {
+    motionPreference.addEventListener('change', onMotionPreferenceChange);
+} else if (motionPreference && typeof motionPreference.addListener === 'function') {
+    motionPreference.addListener(onMotionPreferenceChange);
+}
+
+function ensureBaseClass(target) {
+    if (!target || !target.classList) {
+        return;
+    }
+    target.classList.add(CLASSNAMES.base);
+}
+
+function applyVisibility(target, shouldShow) {
+    if (!target || !target.classList) {
+        return;
+    }
+    target.classList.toggle(CLASSNAMES.visible, Boolean(shouldShow));
+}
+
+function clearAnimationClasses(target) {
+    if (!target || !target.classList) {
+        return;
+    }
+    target.classList.remove(CLASSNAMES.animating, CLASSNAMES.showing, CLASSNAMES.hiding);
+}
 
 export function cancelAppAnimation(target) {
     if (!target) {
@@ -10,125 +64,125 @@ export function cancelAppAnimation(target) {
     if (!state) {
         return;
     }
-    animationStates.delete(target);
-    const { animation, cleanup } = state;
-    if (animation) {
-        try {
-            animation.cancel();
-        } catch (_) {
-            // Ignore animation cancellation errors.
-        }
-    }
-    if (typeof cleanup === 'function') {
-        try {
-            cleanup();
-        } catch (_) {
-            // Ignore cleanup errors.
-        }
+    try {
+        state.cancel();
+    } finally {
+        animationStates.delete(target);
+        activeAnimationStates.delete(state);
     }
 }
 
 export function animateAppVisibility(target, shouldShow) {
-    if (!target || typeof target.animate !== 'function') {
-        return null;
-    }
-    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    if (!target) {
         return null;
     }
 
+    ensureBaseClass(target);
     cancelAppAnimation(target);
+    clearAnimationClasses(target);
 
-    const computed = window.getComputedStyle(target);
-    const currentOpacity = parseFloat(computed.opacity);
-    const startOpacity = isNaN(currentOpacity) ? (shouldShow ? 0 : 1) : currentOpacity;
-    const startTransform = computed.transform && computed.transform !== 'none'
-        ? computed.transform
-        : (shouldShow ? 'translateY(12px)' : 'translateY(0px)');
-    const endTransform = shouldShow ? 'translateY(0px)' : 'translateY(12px)';
-    const endOpacity = shouldShow ? 1 : 0;
+    const prefersReducedMotion = motionPreference && motionPreference.matches;
+    const supportsCssAnimations = typeof target.getAnimations === 'function';
 
-    const previousTransition = target.style.transition;
-    target.style.transition = 'none';
-
-    const previousWillChange = target.style.willChange;
-    let willChangeOverridden = false;
-    if (!previousWillChange) {
-        target.style.willChange = 'opacity, transform';
-        willChangeOverridden = true;
-    }
-
-    const midShowOpacity = Math.min(1, Math.max(startOpacity, 0.85));
-    const midHideOpacity = Math.min(1, Math.max(endOpacity, startOpacity - 0.15));
-    const keyframes = shouldShow
-        ? [
-            { opacity: startOpacity, transform: startTransform },
-            { opacity: midShowOpacity, transform: 'translateY(-4px)', offset: 0.7 },
-            { opacity: endOpacity, transform: endTransform }
-        ]
-        : [
-            { opacity: startOpacity, transform: startTransform },
-            { opacity: midHideOpacity, transform: 'translateY(6px)', offset: 0.35 },
-            { opacity: endOpacity, transform: endTransform }
-        ];
-
-    let animation;
-    try {
-        animation = target.animate(keyframes, {
-            duration: shouldShow ? 460 : 360,
-            easing: shouldShow ? 'cubic-bezier(0.33, 1, 0.68, 1)' : 'cubic-bezier(0.4, 0, 0.2, 1)',
-            fill: 'forwards'
-        });
-    } catch (_) {
-        target.style.transition = previousTransition;
-        if (willChangeOverridden) {
-            target.style.willChange = previousWillChange;
-        }
+    if (!supportsCssAnimations || prefersReducedMotion) {
+        applyVisibility(target, shouldShow);
         return null;
     }
 
-    let cleaned = false;
-    const cleanup = () => {
-        if (cleaned) {
+    target.classList.add(CLASSNAMES.animating);
+    if (shouldShow) {
+        target.classList.remove(CLASSNAMES.visible);
+        target.classList.add(CLASSNAMES.showing);
+    } else {
+        target.classList.add(CLASSNAMES.hiding);
+    }
+
+    const expectedName = shouldShow ? 'app-visibility-show' : 'app-visibility-hide';
+    let animations = [];
+    try {
+        animations = target.getAnimations({ subtree: false });
+    } catch (_) {
+        animations = target.getAnimations();
+    }
+
+    animations = animations.filter(animation => animation.animationName === expectedName);
+
+    if (animations.length === 0) {
+        clearAnimationClasses(target);
+        applyVisibility(target, shouldShow);
+        return null;
+    }
+
+    let state = null;
+    let resolved = false;
+    let resolvePromise = () => {};
+
+    const finalize = () => {
+        if (resolved) {
             return;
         }
-        cleaned = true;
-        target.style.transition = previousTransition;
-        if (willChangeOverridden) {
-            target.style.willChange = previousWillChange;
+        resolved = true;
+        clearAnimationClasses(target);
+        applyVisibility(target, shouldShow);
+        if (state) {
+            animationStates.delete(target);
+            activeAnimationStates.delete(state);
         }
     };
 
-    const state = { animation, cleanup };
-    animationStates.set(target, state);
-
     const promise = new Promise(resolve => {
-        let resolved = false;
-        const finalize = () => {
-            if (resolved) {
-                return;
-            }
-            resolved = true;
-            if (animationStates.get(target) === state) {
-                animationStates.delete(target);
-            }
-            cleanup();
+        resolvePromise = () => {
             resolve();
+            resolvePromise = () => {};
         };
-
-        animation.addEventListener('finish', () => {
-            if (typeof animation.commitStyles === 'function') {
-                try {
-                    animation.commitStyles();
-                } catch (_) {
-                    // Ignore browsers that throw for commitStyles.
-                }
-            }
-            animation.cancel();
+        const finishOnce = () => {
             finalize();
-        }, { once: true });
-
-        animation.addEventListener('cancel', finalize, { once: true });
+            resolvePromise();
+        };
+        animations.forEach(animation => {
+            animation.addEventListener('finish', finishOnce, { once: true });
+            animation.addEventListener('cancel', finishOnce, { once: true });
+        });
     });
+
+    state = {
+        target,
+        shouldShow,
+        cancel() {
+            animations.forEach(animation => {
+                try {
+                    animation.cancel();
+                } catch (_) {
+                    // Ignore cancellation errors.
+                }
+            });
+            finalize();
+            resolvePromise();
+        },
+        finish() {
+            animations.forEach(animation => {
+                try {
+                    if (typeof animation.finish === 'function') {
+                        animation.finish();
+                    } else {
+                        animation.cancel();
+                    }
+                } catch (_) {
+                    try {
+                        animation.cancel();
+                    } catch (_) {
+                        // Ignore finish errors.
+                    }
+                }
+            });
+            finalize();
+            resolvePromise();
+        }
+    };
+
+    animationStates.set(target, state);
+    activeAnimationStates.add(state);
+
     return promise;
 }
 


### PR DESCRIPTION
## Summary
- shorten the app shell visibility durations and remove the overshoot so the fade/slide feels snappier
- switch the keyframes to translate3d and limit the animation lookup to the target element for more stable transitions

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d839991578832d88bc653f23ebef31