### PR TITLE
Refactor service role scripts into module

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -432,7 +432,6 @@
           // Redirects / Local / Service roles (чипы)
           const redirInput = $('#redirInput'), redirList = $('#redirList');
           const locInput   = $('#locInput'),   locList   = $('#locList');
-          const svcList    = $('#svcList');
 
           // Hidden fields (BindProperty)
           const hidClientId      = $('#hidClientId');
@@ -451,12 +450,10 @@
           const hidCreatioEmail  = $('#hidCreatioSecretEmail');
 
           // ---- Chips data
-          const redirs   = @Html.Raw(string.IsNullOrWhiteSpace(Model.RedirectUrisJson) ? "[]" : Model.RedirectUrisJson);
-          const locals   = @Html.Raw(string.IsNullOrWhiteSpace(Model.LocalRolesJson) ? "[]" : Model.LocalRolesJson);
-          const svcRoles = @Html.Raw(string.IsNullOrWhiteSpace(Model.ServiceRolesJson) ? "[]" : Model.ServiceRolesJson);
+          const redirs = @Html.Raw(string.IsNullOrWhiteSpace(Model.RedirectUrisJson) ? "[]" : Model.RedirectUrisJson);
+          const locals = @Html.Raw(string.IsNullOrWhiteSpace(Model.LocalRolesJson) ? "[]" : Model.LocalRolesJson);
           renderChips(redirList, redirs);
           renderChips(locList,  locals);
-          renderChips(svcList,  svcRoles);
 
           // ---- Panels & headers
           const panels = $$('[data-step]');
@@ -665,7 +662,6 @@
 
             hidRedirects.value      = JSON.stringify(redirs);
             hidLocalRoles.value     = JSON.stringify(locals);
-            //hidServiceRoles.value   = JSON.stringify(svcRoles);
 
             hidAppName.value        = trim(appNameInput?.value);
             hidAppUrl.value         = trim(appUrlInput?.value);
@@ -923,379 +919,25 @@
           }
         })();
     </script>
+    <!-- Service Roles module -->
+    <script type="module" data-soft-nav>
+        import { initServiceRoles } from '@Url.Content("~/js/service-roles.js")';
 
-    <!-- Изолированный модуль Service Roles -->
-    <script data-soft-nav>
-        (() => {
-          // helpers
-          const $  = (s, r=document)=>r.querySelector(s);
-          const el = (t, cls, html)=>{ const n=document.createElement(t); if(cls) n.className=cls; if(html!=null) n.innerHTML=html; return n; };
-          const safe = fn => (...a)=>{ try { return fn(...a); } catch(e){ console.error('[ServiceRolesUI]', e); } };
+        const root = document.querySelector('[data-step="7"]');
+        const hiddenInput = document.getElementById('@Html.IdFor(m => m.ServiceRolesJson)')
+            || document.getElementById('hidServiceRoles')
+            || document.querySelector('input[name="ServiceRolesJson"]');
+        const realmSelect = document.getElementById('@Html.IdFor(m => m.Realm)')
+            || document.getElementById('realmSelect')
+            || document.querySelector('select[name="Realm"]');
 
-          // scope: только шаг 7
-          const step = document.querySelector('[data-step="7"]');
-          if (!step) return;
-
-          const realmEl  = document.getElementById("@Html.IdFor(m => m.Realm)") || $('#realmSelect') || $('select[name="Realm"]');
-          const hidRoles = document.getElementById("@Html.IdFor(m => m.ServiceRolesJson)") || $('#hidServiceRoles') || $('input[name="ServiceRolesJson"]');
-
-          const svcList        = $('#svcList', step);
-          const svcSearchInput = $('#svcSearchInput', step);
-          const svcSearchBtn   = $('#svcSearchBtn', step);
-          const svcSearchDd    = $('#svcSearchDd', step);
-
-          const svcChosen      = $('#svcChosen', step);
-          const svcChosenTag   = $('#svcChosenTag', step);
-          const svcChangeBtn   = $('#svcChange', step);
-
-          const svcRoleList    = $('#svcRoleList', step);
-          const btnMoreRoles   = $('#btnMoreRoles', step);
-          const svcErr         = $('#svcErr', step);
-
-          const PAGE_URL = '@Url.Page(null)';
-          const realm = ()=> (realmEl?.value ?? '').trim();
-
-          // --- MIN LEN
-          const MIN_LEN = 3;
-
-          // state
-          const state = {
-            chips: [],
-            currentClient: null,           // { id, clientId, realm }
-            page: 0, size: 50, more: false,
-            cacheClients: new Map(),       // realm|q → [{id,clientId}]
-            cacheClientRoles: new Map(),   // realm|clientId|page → ["roleA",...]
-            lastQuery: '',
-            lastRealm: (realmEl?.value ?? '').trim(),
-            roleScanCursor: 0,
-            roleScanHasMore: false,
-            pendingEmpty: false
-          };
-
-          // utils
-          async function fetchJson(url, opts){
-            const r = await fetch(url, {headers:{'Accept':'application/json'}, ...opts});
-            if(!r.ok) throw new Error(`HTTP ${r.status}`);
-            return r.json();
-          }
-          function hideDd(){ if(!svcSearchDd) return; svcSearchDd.classList.add('hidden'); svcSearchDd.innerHTML=''; svcSearchDd.style.minHeight=''; }
-          function showDd(){ if(!svcSearchDd) return; svcSearchDd.classList.remove('hidden'); }
-          function showInfo(message){
-            if (!svcSearchDd) return;
-            svcSearchDd.innerHTML = '';
-            svcSearchDd.appendChild(el('div', 'px-2 py-1 text-slate-400', message));
-            showDd();
-          }
-          function showError(message, { append = false } = {}){
-            if (!svcSearchDd) return;
-            const node = el('div', 'px-2 py-1 text-rose-400', message);
-            if (append){
-              svcSearchDd.appendChild(node);
-            } else {
-              svcSearchDd.innerHTML = '';
-              svcSearchDd.appendChild(node);
-            }
-            showDd();
-          }
-          function showLoading(){
-            if (!svcSearchDd) return;
-            svcSearchDd.innerHTML = `<div class="px-3 py-2 text-slate-400">Ищем...</div>`;
-            svcSearchDd.style.minHeight = '56px';
-            showDd();
-          }
-
-          // chips persist/restore
-          function persist(){ if(hidRoles) hidRoles.value = JSON.stringify(state.chips); }
-          function renderChips(){
-            if(!svcList) return;
-            svcList.innerHTML = '';
-            for (const s of state.chips){
-              const chip = el('div','kc-chip'); chip.textContent = s;
-              const x = el('button','kc-chip-x','×'); x.type='button'; x.title='Удалить';
-              x.addEventListener('click', safe(()=>{
-                const i = state.chips.indexOf(s);
-                if(i>=0){ state.chips.splice(i,1); renderChips(); persist(); }
-              }));
-              chip.appendChild(x);
-              svcList.appendChild(chip);
-            }
-          }
-          safe(()=>{
-            const raw = hidRoles?.value || '[]';
-            const arr = JSON.parse(raw);
-            if (Array.isArray(arr)) for (const v of arr) if (typeof v === 'string' && !state.chips.includes(v)) state.chips.push(v);
-            renderChips();
-          })();
-
-          // ------- SEARCH: clients + roles (когда клиента не знаем)
-          const cacheClientsKey = (rlm, q) => `${rlm}::${q}`;
-          const cacheClientRolesKey = (rlm, clientId, page) => `${rlm}::${clientId}::${page}`;
-
-          async function searchClients(q, currentRealm){
-            const key = cacheClientsKey(currentRealm, q);
-            if (state.cacheClients.has(key)) return state.cacheClients.get(key);
-            const url = `${PAGE_URL}?handler=ClientsSearch&realm=${encodeURIComponent(currentRealm)}&q=${encodeURIComponent(q)}&first=0&max=12`;
-            const clients = await fetchJson(url); // [{id, clientId}]
-            state.cacheClients.set(key, clients || []);
-            return clients || [];
-          }
-
-          async function searchRolesAcrossClients(q, append=false, isFirst=false, realmOverride){
-            const currentRealm = (realmOverride ?? state.lastRealm ?? realm()) || '';
-            if (!currentRealm){
-              if (isFirst){
-                showInfo('Сначала выберите Realm.');
-              }
-              return;
-            }
-            const url = `${PAGE_URL}?handler=RoleLookup&realm=${encodeURIComponent(currentRealm)}`
-                      + `&q=${encodeURIComponent(q)}&clientFirst=${state.roleScanCursor}&clientsToScan=25&rolesPerClient=10`;
-            let res;
-            try {
-              res = await fetchJson(url); // { hits:[{clientUuid,clientId,role}], nextClientFirst }
-            } catch (e){
-              console.error('[ServiceRolesUI] role lookup failed', e);
-              if (isFirst){
-                const msg = `Не удалось загрузить роли: ${e?.message ?? e}`;
-                if (state.pendingEmpty){
-                  showError(msg);
-                } else {
-                  showError(msg, { append: true });
-                }
-                state.pendingEmpty = false;
-              }
-              return;
-            }
-            const hits = res.hits || [];
-
-            renderRoleHits(hits, append);
-
-            if (typeof res.nextClientFirst === 'number' && res.nextClientFirst >= 0){
-              state.roleScanCursor = res.nextClientFirst;
-              state.roleScanHasMore = true;
-              ensureMoreHitsButton();
-            } else {
-              state.roleScanHasMore = false;
-              removeMoreHitsButton();
-            }
-
-            if (isFirst){
-              if (state.pendingEmpty && hits.length === 0){
-                svcSearchDd.innerHTML = `<div class="px-2 py-1 text-slate-400">Совпадений не найдено</div>`;
-                showDd();
-              }
-              state.pendingEmpty = false;
-            }
-          }
-
-          function ensureMoreHitsButton(){
-            if (!svcSearchDd) return;
-            if (svcSearchDd.querySelector('#roleHitsMoreBtn')) return;
-            const btn = el('button','w-full text-center px-3 py-2 mt-2 hover:bg-slate-700 rounded-md','Показать ещё совпадения');
-            btn.type='button';
-            btn.id='roleHitsMoreBtn';
-            btn.addEventListener('click', safe(()=> searchRolesAcrossClients(state.lastQuery, true, false)));
-            svcSearchDd.appendChild(btn);
-          }
-          function removeMoreHitsButton(){
-            document.getElementById('roleHitsMoreBtn')?.remove();
-          }
-
-          function renderRoleHits(hits, append){
-            if (!svcSearchDd || !hits.length) return;
-            let roleSec = svcSearchDd.querySelector('#roleHitsSection');
-            if (!append){
-              roleSec?.remove();
-              roleSec = el('div', null, '');
-              roleSec.id = 'roleHitsSection';
-              roleSec.appendChild(el('div','kc-mini text-slate-400 px-2 pb-1','Роли (совпадения)'));
-              svcSearchDd.appendChild(roleSec);
-            }
-            for (const m of hits){
-              const line = el('button','w-full text-left px-3 py-2 hover:bg-slate-700 rounded-md');
-              line.type='button';
-              line.textContent = `${m.clientId}: ${m.role}`;
-              line.title = 'Добавить роль';
-              line.addEventListener('click', safe(()=>{
-                const val = `${m.clientId}: ${m.role}`;
-                if (!state.chips.includes(val)){ state.chips.push(val); renderChips(); persist(); }
-                hideDd();
-              }));
-              roleSec.appendChild(line);
-            }
-          }
-
-          // clients list: ТОЛЬКО clientId
-          function renderClientList(clients){
-            if (!svcSearchDd) return;
-            if (!clients.length){
-              showInfo('Совпадений не найдено');
-              return;
-            }
-            const wrap = el('div', null, '');
-            wrap.appendChild(el('div','kc-mini text-slate-400 px-2 pb-1','Клиенты'));
-            clients.forEach(it=>{
-              const line = el('button','w-full text-left px-3 py-2 hover:bg-slate-700 rounded-md');
-              line.type='button';
-              line.textContent = it.clientId;
-              line.addEventListener('click', safe(()=> selectClient(it)));
-              wrap.appendChild(line);
+        if (root && hiddenInput) {
+            initServiceRoles(root, {
+                pageUrl: '@Url.Page(null)',
+                hiddenInput,
+                realmInput: realmSelect,
+                getRealm: () => (realmSelect?.value || '').trim()
             });
-            svcSearchDd.innerHTML = '';               // заменяем лоадер
-            svcSearchDd.appendChild(wrap);
-            svcSearchDd.appendChild(el('div','divider my-2',''));
-            showDd();
-          }
-
-          async function unifiedSearch(qRaw){
-            const q = (qRaw||'').trim();
-            if (q.length < MIN_LEN){
-              svcSearchDd.innerHTML = `<div class="px-2 py-1 text-slate-400">Введите минимум ${MIN_LEN} символа</div>`;
-              showDd();
-              return;
-            }
-
-            const currentRealm = realm();
-            if (!currentRealm){
-              showInfo('Сначала выберите Realm.');
-              return;
-            }
-
-            state.lastQuery = q;
-            state.lastRealm = currentRealm;
-            state.roleScanCursor = 0;
-            state.roleScanHasMore = false;
-            state.pendingEmpty = true;
-            removeMoreHitsButton();
-
-            showLoading();
-
-            // 1) Клиенты — ждём и рисуем
-            let clients = [];
-            try {
-              clients = await searchClients(q, currentRealm);
-            } catch (e){
-              console.error('[ServiceRolesUI] client search failed', e);
-              showError(`Не удалось выполнить поиск: ${e?.message ?? e}`);
-              state.pendingEmpty = false;
-              return;
-            }
-            if (clients.length){
-              renderClientList(clients);
-              state.pendingEmpty = false;
-            }
-
-            // 2) Роли — фоном
-            searchRolesAcrossClients(q, false, true, currentRealm).catch(()=>{});
-          }
-
-          // выбор клиента
-          function selectClient(it){
-            const currentRealm = state.lastRealm || realm();
-            state.currentClient = { id: it.id, clientId: it.clientId, realm: currentRealm };
-            if (svcChosenTag) svcChosenTag.textContent = it.clientId;
-            svcChosen?.classList.remove('hidden');
-            hideDd();
-            if (svcSearchInput) svcSearchInput.value = it.clientId;
-
-            state.page = 0;
-            svcRoleList && (svcRoleList.innerHTML = '');
-            loadRoles({append:false});
-          }
-          svcChangeBtn?.addEventListener('click', safe(()=>{
-            state.currentClient = null;
-            svcChosen?.classList.add('hidden');
-            svcSearchInput?.focus();
-          }));
-
-          // роли клиента, пагинация
-          async function loadRoles({append}){
-            if (svcErr){ svcErr.classList.remove('show'); svcErr.textContent=''; }
-            if (!state.currentClient) return;
-
-            const currentRealm = state.currentClient.realm || realm();
-            if (!currentRealm){
-              svcErr?.classList.add('show');
-              if (svcErr) svcErr.textContent = 'Сначала выберите Realm.';
-              return;
-            }
-
-            const key = cacheClientRolesKey(currentRealm, state.currentClient.clientId, state.page);
-            try{
-              let roles = state.cacheClientRoles.get(key);
-              if (!roles){
-                const url = `${PAGE_URL}?handler=ClientRoles&id=${encodeURIComponent(state.currentClient.id)}&realm=${encodeURIComponent(currentRealm)}&first=${state.page*state.size}&max=${state.size}`;
-                roles = await fetchJson(url);
-                state.cacheClientRoles.set(key, roles || []);
-              }
-              renderRoles(roles || [], {append});
-              state.more = (roles?.length || 0) === state.size;
-              btnMoreRoles?.classList.toggle('hidden', !state.more);
-            }catch(e){
-              if (svcErr){ svcErr.textContent = `Не удалось загрузить роли: ${e.message}`; svcErr.classList.add('show'); }
-            }
-          }
-          function renderRoles(roles, {append}){
-            if (!svcRoleList) return;
-            if (!append) svcRoleList.innerHTML = '';
-            if (!roles.length){
-              if (!append) svcRoleList.innerHTML = `<div class="px-2 py-1 text-slate-400">Ролей не найдено</div>`;
-              return;
-            }
-            roles.forEach(name=>{
-              const item = el('button','kc-card px-3 py-2 hover:bg-slate-700 text-left');
-              item.type = 'button';
-              item.textContent = name;
-              item.title = 'Добавить роль';
-              item.addEventListener('click', safe(()=>{
-                if (!state.currentClient) return;
-                const val = `${state.currentClient.clientId}: ${name}`;
-                if (!state.chips.includes(val)){ state.chips.push(val); renderChips(); persist(); }
-              }));
-              svcRoleList.appendChild(item);
-            });
-          }
-          btnMoreRoles?.addEventListener('click', safe(()=>{
-            state.page += 1;
-            loadRoles({append:true});
-          }));
-
-          // events: дизейблим кнопку до MIN_LEN, мгновенный лоадер + rAF, блок Enter, клик вне
-          const updateBtnState = ()=> { if (svcSearchBtn && svcSearchInput) svcSearchBtn.disabled = (svcSearchInput.value.trim().length < MIN_LEN); };
-          updateBtnState();
-          svcSearchInput?.addEventListener('input', updateBtnState);
-
-          svcSearchBtn?.addEventListener('click', safe(()=>{
-            const q = svcSearchInput?.value || '';
-            showLoading();
-            requestAnimationFrame(()=> unifiedSearch(q));
-          }));
-
-          svcSearchInput?.addEventListener('keydown', e => { if (e.key === 'Enter') e.preventDefault(); });
-          document.addEventListener('click', safe((e)=>{
-            if (!svcSearchDd) return;
-            if (!svcSearchDd.contains(e.target) && e.target !== svcSearchInput && e.target !== svcSearchBtn) hideDd();
-          }));
-
-          function resetForRealmChange(){
-            state.cacheClients.clear();
-            state.cacheClientRoles.clear();
-            state.currentClient = null;
-            state.page = 0;
-            state.more = false;
-            state.lastQuery = '';
-            state.lastRealm = (realmEl?.value ?? '').trim();
-            state.roleScanCursor = 0;
-            state.roleScanHasMore = false;
-            state.pendingEmpty = false;
-            hideDd();
-            svcChosen?.classList.add('hidden');
-            svcRoleList && (svcRoleList.innerHTML = '');
-            if (svcErr){ svcErr.classList.remove('show'); svcErr.textContent=''; }
-            if (svcSearchInput){ svcSearchInput.value=''; updateBtnState(); }
-          }
-
-          realmEl?.addEventListener('change', safe(resetForRealmChange));
-        })();
+        }
     </script>
 }

--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -491,8 +491,7 @@
 @section Scripts {
     <script data-soft-nav>
         (() => {
-          const svcRoles = JSON.parse('@Html.Raw(Model.ServiceRolesJson)');
-          (function(svcRoles){
+          (function(){
           // ---------- Вкладки ----------
           const btns  = document.querySelectorAll('.tab-btn');
           const panes = document.querySelectorAll('.tab-pane');
@@ -1031,257 +1030,26 @@
             // массивы
             document.getElementById('hidRedirects').value    = JSON.stringify(redirs);
             document.getElementById('hidLocalRoles').value   = JSON.stringify(locals);
-            document.getElementById('hidServiceRoles').value = JSON.stringify(svcRoles);
           }
           btnDelete?.addEventListener('click', e=>{ if(!confirm('Вы действительно хотите удалить клиента?')) e.preventDefault(); });
           saveForm?.addEventListener('submit', collect);
-        })(svcRoles);
-        (function(svcRoles){
-          const $  = (s, r=document)=>r.querySelector(s);
-          const el = (t, cls, html)=>{ const n=document.createElement(t); if(cls) n.className=cls; if(html!=null) n.innerHTML=html; return n; };
-          const safe = fn => (...a)=>{ try { return fn(...a); } catch(e){ console.error('[ServiceRolesUI]', e); } };
-
-          const hidRoles       = document.getElementById('hidServiceRoles');
-          const svcList        = $('#svcList');
-          const svcSearchInput = $('#svcSearchInput');
-          const svcSearchBtn   = $('#svcSearchBtn');
-          const svcSearchDd    = $('#svcSearchDd');
-
-          const svcChosen      = $('#svcChosen');
-          const svcChosenTag   = $('#svcChosenTag');
-          const svcChangeBtn   = $('#svcChange');
-
-          const svcRoleList    = $('#svcRoleList');
-          const btnMoreRoles   = $('#btnMoreRoles');
-          const svcErr         = $('#svcErr');
-
-          const PAGE_URL = '@Url.Page(null)';
-          const realm = '@realm';
-          const MIN_LEN = 3;
-
-          const state = {
-            chips: Array.isArray(svcRoles) ? svcRoles : [],
-            currentClient: null,
-            page: 0, size: 50, more: false,
-            cacheClients: new Map(),
-            cacheClientRoles: new Map(),
-            lastQuery: '',
-            roleScanCursor: 0,
-            roleScanHasMore: false,
-            pendingEmpty: false
-          };
-
-          function persist(){ if(hidRoles) hidRoles.value = JSON.stringify(state.chips); }
-
-          function renderChips(){
-            if(!svcList) return;
-            svcList.innerHTML = '';
-            for (const s of state.chips){
-              const chip = el('div','kc-chip'); chip.textContent = s;
-              const x = el('button','kc-chip-x','×'); x.type='button'; x.title='Удалить';
-              x.addEventListener('click', safe(()=>{
-                const i = state.chips.indexOf(s);
-                if(i>=0){ state.chips.splice(i,1); renderChips(); persist(); }
-              }));
-              chip.appendChild(x);
-              svcList.appendChild(chip);
-            }
-          }
-          renderChips(); persist();
-
-          async function fetchJson(url, opts){
-            const r = await fetch(url, {headers:{'Accept':'application/json'}, ...opts});
-            if(!r.ok) throw new Error(`HTTP ${r.status}`);
-            return r.json();
-          }
-          function hideDd(){ if(!svcSearchDd) return; svcSearchDd.classList.add('hidden'); svcSearchDd.innerHTML=''; svcSearchDd.style.minHeight=''; }
-          function showDd(){ if(!svcSearchDd) return; svcSearchDd.classList.remove('hidden'); }
-          function showLoading(){
-            if (!svcSearchDd) return;
-            svcSearchDd.innerHTML = `<div class="px-3 py-2 text-slate-400">Ищем...</div>`;
-            svcSearchDd.style.minHeight = '56px';
-            showDd();
-          }
-
-          async function searchClients(q){
-            if (state.cacheClients.has(q)) return state.cacheClients.get(q);
-            const url = `${PAGE_URL}?handler=ClientsSearch&realm=${encodeURIComponent(realm)}&q=${encodeURIComponent(q)}&first=0&max=12`;
-            const clients = await fetchJson(url);
-            state.cacheClients.set(q, clients || []);
-            return clients || [];
-          }
-
-          async function searchRolesAcrossClients(q, append=false, isFirst=false){
-            const url = `${PAGE_URL}?handler=RoleLookup&realm=${encodeURIComponent(realm)}&q=${encodeURIComponent(q)}&clientFirst=${state.roleScanCursor}&clientsToScan=25&rolesPerClient=10`;
-            const res = await fetchJson(url);
-            const hits = res.hits || [];
-            renderRoleHits(hits, append);
-            if (typeof res.nextClientFirst === 'number' && res.nextClientFirst >= 0){
-              state.roleScanCursor = res.nextClientFirst;
-              state.roleScanHasMore = true;
-              ensureMoreHitsButton();
-            } else {
-              state.roleScanHasMore = false;
-              removeMoreHitsButton();
-            }
-            if (isFirst){
-              if (state.pendingEmpty && hits.length === 0){
-                svcSearchDd.innerHTML = `<div class="px-2 py-1 text-slate-400">Совпадений не найдено</div>`;
-                showDd();
-              }
-              state.pendingEmpty = false;
-            }
-          }
-
-          function ensureMoreHitsButton(){
-            if (!svcSearchDd) return;
-            if (svcSearchDd.querySelector('#roleHitsMoreBtn')) return;
-            const btn = el('button','w-full text-center px-3 py-2 mt-2 hover:bg-slate-700 rounded-md','Показать ещё совпадения');
-            btn.type='button';
-            btn.id='roleHitsMoreBtn';
-            btn.addEventListener('click', safe(()=> searchRolesAcrossClients(state.lastQuery, true, false)));
-            svcSearchDd.appendChild(btn);
-          }
-          function removeMoreHitsButton(){
-            document.getElementById('roleHitsMoreBtn')?.remove();
-          }
-
-          function renderRoleHits(hits, append){
-            if (!svcSearchDd || !hits.length) return;
-            let roleSec = svcSearchDd.querySelector('#roleHitsSection');
-            if (!append){
-              roleSec?.remove();
-              roleSec = el('div', null, '');
-              roleSec.id = 'roleHitsSection';
-              roleSec.appendChild(el('div','kc-mini text-slate-400 px-2 pb-1','Роли (совпадения)'));
-              svcSearchDd.appendChild(roleSec);
-            }
-            hits.forEach(it=>{
-              const line = el('button','w-full text-left px-3 py-2 hover:bg-slate-700 rounded-md');
-              line.type='button';
-              line.textContent = `${it.clientId}: ${it.role}`;
-              line.addEventListener('click', safe(()=>{
-                const val = `${it.clientId}: ${it.role}`;
-                if (!state.chips.includes(val)){ state.chips.push(val); renderChips(); persist(); }
-              }));
-              roleSec.appendChild(line);
-            });
-          }
-
-          function renderClientList(clients){
-            if (!svcSearchDd) return;
-            if (!clients.length){ svcSearchDd.innerHTML = `<div class="px-2 py-1 text-slate-400">Совпадений не найдено</div>`; showDd(); return; }
-            const wrap = el('div', null, '');
-            clients.forEach(it=>{
-              const line = el('button','w-full text-left px-3 py-2 hover:bg-slate-700 rounded-md');
-              line.type='button';
-              line.textContent = it.clientId;
-              line.addEventListener('click', safe(()=> selectClient(it)));
-              wrap.appendChild(line);
-            });
-            svcSearchDd.innerHTML = '';
-            svcSearchDd.appendChild(wrap);
-            svcSearchDd.appendChild(el('div','divider my-2',''));
-            showDd();
-          }
-
-          async function unifiedSearch(qRaw){
-            const q = (qRaw||'').trim();
-            if (q.length < MIN_LEN){
-              svcSearchDd.innerHTML = `<div class="px-2 py-1 text-slate-400">Введите минимум ${MIN_LEN} символа</div>`;
-              showDd();
-              return;
-            }
-            state.lastQuery = q;
-            state.roleScanCursor = 0;
-            state.roleScanHasMore = false;
-            state.pendingEmpty = true;
-            removeMoreHitsButton();
-            showLoading();
-            const clients = await searchClients(q);
-            if (clients.length){
-              renderClientList(clients);
-              state.pendingEmpty = false;
-            }
-            searchRolesAcrossClients(q, false, true).catch(()=>{});
-          }
-
-          function selectClient(it){
-            state.currentClient = { id: it.id, clientId: it.clientId };
-            if (svcChosenTag) svcChosenTag.textContent = it.clientId;
-            svcChosen?.classList.remove('hidden');
-            hideDd();
-            if (svcSearchInput) svcSearchInput.value = it.clientId;
-            state.page = 0;
-            svcRoleList && (svcRoleList.innerHTML = '');
-            loadRoles({append:false});
-          }
-          svcChangeBtn?.addEventListener('click', safe(()=>{
-            state.currentClient = null;
-            svcChosen?.classList.add('hidden');
-            svcSearchInput?.focus();
-          }));
-
-          async function loadRoles({append}){
-            if (svcErr){ svcErr.classList.remove('show'); svcErr.textContent=''; }
-            if (!state.currentClient) return;
-
-            const key = `${state.currentClient.clientId}|${state.page}`;
-            try{
-              let roles = state.cacheClientRoles.get(key);
-              if (!roles){
-                const url = `${PAGE_URL}?handler=ClientRoles&id=${encodeURIComponent(state.currentClient.id)}&realm=${encodeURIComponent(realm)}&first=${state.page*state.size}&max=${state.size}`;
-                roles = await fetchJson(url);
-                state.cacheClientRoles.set(key, roles || []);
-              }
-              renderRoles(roles || [], {append});
-              state.more = (roles?.length || 0) === state.size;
-              btnMoreRoles?.classList.toggle('hidden', !state.more);
-            }catch(e){
-              if (svcErr){ svcErr.textContent = `Не удалось загрузить роли: ${e.message}`; svcErr.classList.add('show'); }
-            }
-          }
-          function renderRoles(roles, {append}){
-            if (!svcRoleList) return;
-            if (!append) svcRoleList.innerHTML = '';
-            if (!roles.length){
-              if (!append) svcRoleList.innerHTML = `<div class="px-2 py-1 text-slate-400">Ролей не найдено</div>`;
-              return;
-            }
-            roles.forEach(name=>{
-              const item = el('button','kc-card px-3 py-2 hover:bg-slate-700 text-left');
-              item.type = 'button';
-              item.textContent = name;
-              item.title = 'Добавить роль';
-              item.addEventListener('click', safe(()=>{
-                if (!state.currentClient) return;
-                const val = `${state.currentClient.clientId}: ${name}`;
-                if (!state.chips.includes(val)){ state.chips.push(val); renderChips(); persist(); }
-              }));
-              svcRoleList.appendChild(item);
-            });
-          }
-          btnMoreRoles?.addEventListener('click', safe(()=>{
-            state.page += 1;
-            loadRoles({append:true});
-          }));
-
-          const updateBtnState = ()=> { if (svcSearchBtn && svcSearchInput) svcSearchBtn.disabled = (svcSearchInput.value.trim().length < MIN_LEN); };
-          updateBtnState();
-          svcSearchInput?.addEventListener('input', updateBtnState);
-
-          svcSearchBtn?.addEventListener('click', safe(()=>{
-            const q = svcSearchInput?.value || '';
-            showLoading();
-            requestAnimationFrame(()=> unifiedSearch(q));
-          }));
-
-          svcSearchInput?.addEventListener('keydown', e => { if (e.key === 'Enter') e.preventDefault(); });
-          document.addEventListener('click', safe((e)=>{
-            if (!svcSearchDd) return;
-            if (!svcSearchDd.contains(e.target) && e.target !== svcSearchInput && e.target !== svcSearchBtn) hideDd();
-          }));
-        })(svcRoles);
         })();
+        })();
+    </script>
+    <script type="module" data-soft-nav>
+        import { initServiceRoles } from '@Url.Content("~/js/service-roles.js")';
+
+        const root = document.querySelector('.tab-pane[data-tab="ServiceRoles"]');
+        const hiddenInput = document.getElementById('hidServiceRoles');
+        const initialRoles = JSON.parse('@Html.Raw(Model.ServiceRolesJson)');
+
+        if (root && hiddenInput) {
+            initServiceRoles(root, {
+                pageUrl: '@Url.Page(null)',
+                hiddenInput,
+                getRealm: () => '@realm',
+                initialRoles: Array.isArray(initialRoles) ? initialRoles : []
+            });
+        }
     </script>
   }

--- a/wwwroot/js/service-roles.js
+++ b/wwwroot/js/service-roles.js
@@ -1,0 +1,633 @@
+const DEFAULT_MIN_QUERY = 3;
+const DEFAULT_PAGE_SIZE = 50;
+
+function createElement(tag, className, html) {
+    const node = document.createElement(tag);
+    if (className) {
+        node.className = className;
+    }
+    if (html != null) {
+        node.innerHTML = html;
+    }
+    return node;
+}
+
+function safe(fn) {
+    return (...args) => {
+        try {
+            return fn(...args);
+        } catch (error) {
+            console.error('[ServiceRolesUI]', error);
+            return undefined;
+        }
+    };
+}
+
+function isAbortSignal(value) {
+    return typeof AbortSignal !== 'undefined' && value instanceof AbortSignal;
+}
+
+function normalizeController(options) {
+    if (!options) {
+        return { controller: null, signal: null };
+    }
+
+    if (options.abortController && typeof options.abortController.abort === 'function') {
+        return { controller: options.abortController, signal: options.abortController.signal };
+    }
+
+    if (isAbortSignal(options.signal)) {
+        return { controller: null, signal: options.signal };
+    }
+
+    if (options.signal && typeof options.signal.abort === 'function') {
+        const ctrl = options.signal;
+        return { controller: ctrl, signal: ctrl.signal };
+    }
+
+    const controller = new AbortController();
+    return { controller, signal: controller.signal };
+}
+
+export function initServiceRoles(root, options = {}) {
+    if (!root || !(root instanceof HTMLElement)) {
+        return null;
+    }
+
+    const pageUrl = options.pageUrl || '';
+    if (!pageUrl) {
+        console.warn('[ServiceRolesUI] Missing pageUrl option.');
+        return null;
+    }
+
+    const hiddenInput = options.hiddenInput instanceof HTMLElement ? options.hiddenInput : null;
+    const realmInput = options.realmInput instanceof HTMLElement ? options.realmInput : null;
+    const minQueryLength = typeof options.minQueryLength === 'number' ? Math.max(1, options.minQueryLength) : DEFAULT_MIN_QUERY;
+    const pageSize = typeof options.pageSize === 'number' && options.pageSize > 0 ? options.pageSize : DEFAULT_PAGE_SIZE;
+
+    const getRealm = typeof options.getRealm === 'function'
+        ? () => {
+            try {
+                return (options.getRealm() || '').trim();
+            } catch (error) {
+                console.error('[ServiceRolesUI] getRealm failed', error);
+                return '';
+            }
+        }
+        : () => (typeof options.realm === 'string' ? options.realm.trim() : '');
+
+    const { controller, signal } = normalizeController(options);
+    if (controller && typeof window.__softNavRegisterTeardown === 'function') {
+        window.__softNavRegisterTeardown(controller);
+    }
+
+    const addEvent = (target, type, handler, opts) => {
+        if (!target || typeof target.addEventListener !== 'function') {
+            return;
+        }
+        const finalHandler = safe(handler);
+        if (signal) {
+            const optionsWithSignal = Object.assign({}, opts || {}, { signal });
+            target.addEventListener(type, finalHandler, optionsWithSignal);
+        } else {
+            target.addEventListener(type, finalHandler, opts);
+        }
+    };
+
+    const query = (selector) => root.querySelector(selector);
+
+    const svcList = query('#svcList');
+    const svcSearchInput = query('#svcSearchInput');
+    const svcSearchBtn = query('#svcSearchBtn');
+    const svcSearchDd = query('#svcSearchDd');
+    const svcChosen = query('#svcChosen');
+    const svcChosenTag = query('#svcChosenTag');
+    const svcChangeBtn = query('#svcChange');
+    const svcRoleList = query('#svcRoleList');
+    const btnMoreRoles = query('#btnMoreRoles');
+    const svcErr = query('#svcErr');
+
+    if (!svcList || !svcSearchInput || !svcSearchDd) {
+        console.warn('[ServiceRolesUI] Required markup not found inside root.');
+        return null;
+    }
+
+    const state = {
+        chips: [],
+        currentClient: null,
+        page: 0,
+        size: pageSize,
+        more: false,
+        cacheClients: new Map(),
+        cacheClientRoles: new Map(),
+        lastQuery: '',
+        lastRealm: (getRealm() || ''),
+        roleScanCursor: 0,
+        roleScanHasMore: false,
+        pendingEmpty: false
+    };
+
+    const persist = () => {
+        if (hiddenInput) {
+            hiddenInput.value = JSON.stringify(state.chips);
+        }
+        if (typeof options.onChange === 'function') {
+            options.onChange([...state.chips]);
+        }
+    };
+
+    const renderChips = () => {
+        if (!svcList) {
+            return;
+        }
+        svcList.innerHTML = '';
+        for (const chipValue of state.chips) {
+            const chip = createElement('div', 'kc-chip');
+            chip.textContent = chipValue;
+            const closeBtn = createElement('button', 'kc-chip-x', '×');
+            closeBtn.type = 'button';
+            closeBtn.title = 'Удалить';
+            addEvent(closeBtn, 'click', () => {
+                const idx = state.chips.indexOf(chipValue);
+                if (idx >= 0) {
+                    state.chips.splice(idx, 1);
+                    renderChips();
+                    persist();
+                }
+            });
+            chip.appendChild(closeBtn);
+            svcList.appendChild(chip);
+        }
+    };
+
+    const loadInitialChips = () => {
+        const initial = Array.isArray(options.initialRoles) ? options.initialRoles : null;
+        if (initial && initial.length) {
+            for (const value of initial) {
+                if (typeof value === 'string' && !state.chips.includes(value)) {
+                    state.chips.push(value);
+                }
+            }
+        } else if (hiddenInput && hiddenInput.value) {
+            try {
+                const parsed = JSON.parse(hiddenInput.value);
+                if (Array.isArray(parsed)) {
+                    for (const value of parsed) {
+                        if (typeof value === 'string' && !state.chips.includes(value)) {
+                            state.chips.push(value);
+                        }
+                    }
+                }
+            } catch (error) {
+                console.error('[ServiceRolesUI] Failed to parse hidden input value', error);
+            }
+        }
+        renderChips();
+        persist();
+    };
+
+    const cacheClientsKey = (realm, queryText) => `${realm}::${queryText}`;
+    const cacheClientRolesKey = (realm, clientId, page) => `${realm}::${clientId}::${page}`;
+
+    const hideDd = () => {
+        if (!svcSearchDd) {
+            return;
+        }
+        svcSearchDd.classList.add('hidden');
+        svcSearchDd.innerHTML = '';
+        svcSearchDd.style.minHeight = '';
+    };
+
+    const showDd = () => {
+        if (!svcSearchDd) {
+            return;
+        }
+        svcSearchDd.classList.remove('hidden');
+    };
+
+    const showInfo = (message) => {
+        if (!svcSearchDd) {
+            return;
+        }
+        svcSearchDd.innerHTML = '';
+        svcSearchDd.appendChild(createElement('div', 'px-2 py-1 text-slate-400', message));
+        showDd();
+    };
+
+    const showError = (message, { append = false } = {}) => {
+        if (!svcSearchDd) {
+            return;
+        }
+        const node = createElement('div', 'px-2 py-1 text-rose-400', message);
+        if (append) {
+            svcSearchDd.appendChild(node);
+        } else {
+            svcSearchDd.innerHTML = '';
+            svcSearchDd.appendChild(node);
+        }
+        showDd();
+    };
+
+    const showLoading = () => {
+        if (!svcSearchDd) {
+            return;
+        }
+        svcSearchDd.innerHTML = '<div class="px-3 py-2 text-slate-400">Ищем...</div>';
+        svcSearchDd.style.minHeight = '56px';
+        showDd();
+    };
+
+    const fetchJson = async (url, init) => {
+        const finalInit = Object.assign({}, init || {});
+        const headers = new Headers(finalInit.headers || {});
+        if (!headers.has('Accept')) {
+            headers.set('Accept', 'application/json');
+        }
+        finalInit.headers = headers;
+        if (signal && !finalInit.signal) {
+            finalInit.signal = signal;
+        }
+        const response = await fetch(url, finalInit);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        return response.json();
+    };
+
+    const ensureMoreHitsButton = () => {
+        if (!svcSearchDd) {
+            return;
+        }
+        if (svcSearchDd.querySelector('#roleHitsMoreBtn')) {
+            return;
+        }
+        const btn = createElement('button', 'w-full text-center px-3 py-2 mt-2 hover:bg-slate-700 rounded-md', 'Показать ещё совпадения');
+        btn.type = 'button';
+        btn.id = 'roleHitsMoreBtn';
+        addEvent(btn, 'click', () => searchRolesAcrossClients(state.lastQuery, true, false));
+        svcSearchDd.appendChild(btn);
+    };
+
+    const removeMoreHitsButton = () => {
+        const btn = document.getElementById('roleHitsMoreBtn');
+        if (btn) {
+            btn.remove();
+        }
+    };
+
+    const renderRoleHits = (hits, append) => {
+        if (!svcSearchDd || !hits.length) {
+            return;
+        }
+        let roleSection = svcSearchDd.querySelector('#roleHitsSection');
+        if (!append) {
+            if (roleSection) {
+                roleSection.remove();
+            }
+            roleSection = createElement('div', null, '');
+            roleSection.id = 'roleHitsSection';
+            roleSection.appendChild(createElement('div', 'kc-mini text-slate-400 px-2 pb-1', 'Роли (совпадения)'));
+            svcSearchDd.appendChild(roleSection);
+        }
+        for (const match of hits) {
+            const line = createElement('button', 'w-full text-left px-3 py-2 hover:bg-slate-700 rounded-md');
+            line.type = 'button';
+            line.textContent = `${match.clientId}: ${match.role}`;
+            line.title = 'Добавить роль';
+            addEvent(line, 'click', () => {
+                const value = `${match.clientId}: ${match.role}`;
+                if (!state.chips.includes(value)) {
+                    state.chips.push(value);
+                    renderChips();
+                    persist();
+                }
+                hideDd();
+            });
+            roleSection.appendChild(line);
+        }
+    };
+
+    const renderClientList = (clients) => {
+        if (!svcSearchDd) {
+            return;
+        }
+        if (!clients.length) {
+            showInfo('Совпадений не найдено');
+            return;
+        }
+        const wrap = createElement('div', null, '');
+        wrap.appendChild(createElement('div', 'kc-mini text-slate-400 px-2 pb-1', 'Клиенты'));
+        clients.forEach(client => {
+            const line = createElement('button', 'w-full text-left px-3 py-2 hover:bg-slate-700 rounded-md');
+            line.type = 'button';
+            line.textContent = client.clientId;
+            addEvent(line, 'click', () => selectClient(client));
+            wrap.appendChild(line);
+        });
+        svcSearchDd.innerHTML = '';
+        svcSearchDd.appendChild(wrap);
+        svcSearchDd.appendChild(createElement('div', 'divider my-2', ''));
+        showDd();
+    };
+
+    const searchClients = async (queryText, realmValue) => {
+        const key = cacheClientsKey(realmValue, queryText);
+        if (state.cacheClients.has(key)) {
+            return state.cacheClients.get(key);
+        }
+        const url = `${pageUrl}?handler=ClientsSearch&realm=${encodeURIComponent(realmValue)}&q=${encodeURIComponent(queryText)}&first=0&max=12`;
+        const clients = await fetchJson(url);
+        state.cacheClients.set(key, Array.isArray(clients) ? clients : []);
+        return state.cacheClients.get(key);
+    };
+
+    const searchRolesAcrossClients = async (queryText, append = false, isFirst = false, realmOverride) => {
+        const currentRealm = (realmOverride ?? state.lastRealm ?? getRealm() ?? '').trim();
+        if (!currentRealm) {
+            if (isFirst) {
+                showInfo('Сначала выберите Realm.');
+            }
+            return;
+        }
+        const url = `${pageUrl}?handler=RoleLookup&realm=${encodeURIComponent(currentRealm)}`
+            + `&q=${encodeURIComponent(queryText)}&clientFirst=${state.roleScanCursor}&clientsToScan=25&rolesPerClient=10`;
+        let response;
+        try {
+            response = await fetchJson(url);
+        } catch (error) {
+            if (error && error.name === 'AbortError') {
+                return;
+            }
+            console.error('[ServiceRolesUI] role lookup failed', error);
+            if (isFirst) {
+                const message = `Не удалось загрузить роли: ${error?.message ?? error}`;
+                if (state.pendingEmpty) {
+                    showError(message);
+                } else {
+                    showError(message, { append: true });
+                }
+                state.pendingEmpty = false;
+            }
+            return;
+        }
+        const hits = Array.isArray(response?.hits) ? response.hits : [];
+        renderRoleHits(hits, append);
+
+        if (typeof response?.nextClientFirst === 'number' && response.nextClientFirst >= 0) {
+            state.roleScanCursor = response.nextClientFirst;
+            state.roleScanHasMore = true;
+            ensureMoreHitsButton();
+        } else {
+            state.roleScanHasMore = false;
+            removeMoreHitsButton();
+        }
+
+        if (isFirst) {
+            if (state.pendingEmpty && hits.length === 0) {
+                svcSearchDd.innerHTML = '<div class="px-2 py-1 text-slate-400">Совпадений не найдено</div>';
+                showDd();
+            }
+            state.pendingEmpty = false;
+        }
+    };
+
+    const renderRoles = (roles, { append }) => {
+        if (!svcRoleList) {
+            return;
+        }
+        if (!append) {
+            svcRoleList.innerHTML = '';
+        }
+        if (!roles.length) {
+            if (!append) {
+                svcRoleList.innerHTML = '<div class="px-2 py-1 text-slate-400">Ролей не найдено</div>';
+            }
+            return;
+        }
+        roles.forEach(roleName => {
+            const item = createElement('button', 'kc-card px-3 py-2 hover:bg-slate-700 text-left');
+            item.type = 'button';
+            item.textContent = roleName;
+            item.title = 'Добавить роль';
+            addEvent(item, 'click', () => {
+                if (!state.currentClient) {
+                    return;
+                }
+                const value = `${state.currentClient.clientId}: ${roleName}`;
+                if (!state.chips.includes(value)) {
+                    state.chips.push(value);
+                    renderChips();
+                    persist();
+                }
+            });
+            svcRoleList.appendChild(item);
+        });
+    };
+
+    const loadRoles = async ({ append }) => {
+        if (svcErr) {
+            svcErr.classList.remove('show');
+            svcErr.textContent = '';
+        }
+        if (!state.currentClient) {
+            return;
+        }
+        const currentRealm = (state.currentClient.realm || getRealm() || '').trim();
+        if (!currentRealm) {
+            if (svcErr) {
+                svcErr.classList.add('show');
+                svcErr.textContent = 'Сначала выберите Realm.';
+            }
+            return;
+        }
+        const cacheKey = cacheClientRolesKey(currentRealm, state.currentClient.clientId, state.page);
+        try {
+            let roles = state.cacheClientRoles.get(cacheKey);
+            if (!roles) {
+                const url = `${pageUrl}?handler=ClientRoles&id=${encodeURIComponent(state.currentClient.id)}&realm=${encodeURIComponent(currentRealm)}&first=${state.page * state.size}&max=${state.size}`;
+                roles = await fetchJson(url);
+                state.cacheClientRoles.set(cacheKey, Array.isArray(roles) ? roles : []);
+            }
+            renderRoles(state.cacheClientRoles.get(cacheKey), { append });
+            state.more = (state.cacheClientRoles.get(cacheKey)?.length || 0) === state.size;
+            if (btnMoreRoles) {
+                btnMoreRoles.classList.toggle('hidden', !state.more);
+            }
+        } catch (error) {
+            if (error && error.name === 'AbortError') {
+                return;
+            }
+            if (svcErr) {
+                svcErr.textContent = `Не удалось загрузить роли: ${error.message}`;
+                svcErr.classList.add('show');
+            }
+        }
+    };
+
+    const selectClient = (client) => {
+        const realmValue = state.lastRealm || getRealm();
+        state.currentClient = { id: client.id, clientId: client.clientId, realm: realmValue };
+        if (svcChosenTag) {
+            svcChosenTag.textContent = client.clientId;
+        }
+        if (svcChosen) {
+            svcChosen.classList.remove('hidden');
+        }
+        hideDd();
+        if (svcSearchInput) {
+            svcSearchInput.value = client.clientId;
+        }
+        state.page = 0;
+        if (svcRoleList) {
+            svcRoleList.innerHTML = '';
+        }
+        loadRoles({ append: false });
+    };
+
+    const unifiedSearch = async (rawQuery) => {
+        const queryText = (rawQuery || '').trim();
+        if (queryText.length < minQueryLength) {
+            svcSearchDd.innerHTML = `<div class="px-2 py-1 text-slate-400">Введите минимум ${minQueryLength} символа</div>`;
+            showDd();
+            return;
+        }
+        const currentRealm = getRealm();
+        if (!currentRealm) {
+            showInfo('Сначала выберите Realm.');
+            return;
+        }
+        state.lastQuery = queryText;
+        state.lastRealm = currentRealm;
+        state.roleScanCursor = 0;
+        state.roleScanHasMore = false;
+        state.pendingEmpty = true;
+        removeMoreHitsButton();
+        showLoading();
+        let clients = [];
+        try {
+            clients = await searchClients(queryText, currentRealm);
+        } catch (error) {
+            if (error && error.name === 'AbortError') {
+                return;
+            }
+            console.error('[ServiceRolesUI] client search failed', error);
+            showError(`Не удалось выполнить поиск: ${error?.message ?? error}`);
+            state.pendingEmpty = false;
+            return;
+        }
+        if (clients.length) {
+            renderClientList(clients);
+            state.pendingEmpty = false;
+        }
+        searchRolesAcrossClients(queryText, false, true, currentRealm).catch(() => { /* ignored */ });
+    };
+
+    const updateBtnState = () => {
+        if (!svcSearchBtn || !svcSearchInput) {
+            return;
+        }
+        svcSearchBtn.disabled = svcSearchInput.value.trim().length < minQueryLength;
+    };
+
+    const resetForRealmChange = () => {
+        state.cacheClients.clear();
+        state.cacheClientRoles.clear();
+        state.currentClient = null;
+        state.page = 0;
+        state.more = false;
+        state.lastQuery = '';
+        state.lastRealm = getRealm();
+        state.roleScanCursor = 0;
+        state.roleScanHasMore = false;
+        state.pendingEmpty = false;
+        hideDd();
+        if (svcChosen) {
+            svcChosen.classList.add('hidden');
+        }
+        if (svcRoleList) {
+            svcRoleList.innerHTML = '';
+        }
+        if (svcErr) {
+            svcErr.classList.remove('show');
+            svcErr.textContent = '';
+        }
+        if (svcSearchInput) {
+            svcSearchInput.value = '';
+        }
+        updateBtnState();
+    };
+
+    // Initial state and listeners
+    loadInitialChips();
+
+    updateBtnState();
+
+    addEvent(svcSearchInput, 'input', updateBtnState);
+
+    addEvent(svcSearchBtn, 'click', () => {
+        const queryText = svcSearchInput ? svcSearchInput.value || '' : '';
+        showLoading();
+        requestAnimationFrame(() => {
+            unifiedSearch(queryText);
+        });
+    });
+
+    addEvent(svcSearchInput, 'keydown', (event) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+        }
+    });
+
+    addEvent(document, 'click', (event) => {
+        if (!svcSearchDd) {
+            return;
+        }
+        const target = event.target;
+        if (!(target instanceof Node)) {
+            return;
+        }
+        if (!svcSearchDd.contains(target) && target !== svcSearchInput && target !== svcSearchBtn) {
+            hideDd();
+        }
+    });
+
+    addEvent(btnMoreRoles, 'click', () => {
+        state.page += 1;
+        loadRoles({ append: true });
+    });
+
+    addEvent(svcChangeBtn, 'click', () => {
+        state.currentClient = null;
+        if (svcChosen) {
+            svcChosen.classList.add('hidden');
+        }
+        if (svcSearchInput) {
+            svcSearchInput.focus();
+        }
+    });
+
+    if (realmInput) {
+        addEvent(realmInput, 'change', resetForRealmChange);
+    }
+
+    const abortCleanup = () => {
+        removeMoreHitsButton();
+        hideDd();
+    };
+
+    if (isAbortSignal(signal)) {
+        signal.addEventListener('abort', abortCleanup, { once: true });
+    } else if (controller && isAbortSignal(controller.signal)) {
+        controller.signal.addEventListener('abort', abortCleanup, { once: true });
+    }
+
+    return {
+        getRoles: () => [...state.chips],
+        reset: resetForRealmChange,
+        abort: () => {
+            if (controller && typeof controller.abort === 'function') {
+                controller.abort();
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- move the service roles UI logic into a reusable JavaScript module that wires cleanup through AbortController
- expose a soft-navigation teardown helper so modules can remove listeners on page swaps
- update the client Create and Details pages to import the new module with type="module" scripts

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8532e5e5c832db910e89fd96c3c0a