### PR TITLE
Cache sorted step ids for enabled steps

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -459,6 +459,7 @@
           const panels = $$('[data-step]');
           const heads  = $$('[id^="stepHead"]');
           const stepNum = (el)=> +el.getAttribute('data-step') || +el.id.replace('stepHead','');
+          const sortedStepIds = panels.map(stepNum).sort((a,b)=>a-b);
 
           // Условия включения шагов
           const predicates =
@@ -468,11 +469,7 @@
             8: ()=> isAdmin && (swClientAuth?.checked ?? false),
           };
 
-          const enabledSteps = () =>
-          {
-            const nums = panels.map(stepNum).sort((a,b)=>a-b);
-            return nums.filter(n => (predicates[n] ? predicates[n]() : true));
-          };
+          const enabledSteps = () => sortedStepIds.filter(n => (predicates[n] ? predicates[n]() : true));
 
           // ---- Realm description
           function updateRealmDesc()


### PR DESCRIPTION
## Summary
- precompute the sorted list of step identifiers next to the panel/header declarations
- reuse the cached ordering when computing enabled steps while still applying the predicates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d878116dac832db29c82684c6ada2e