### PR TITLE
Use DOM cloning when refreshing toast host

### DIFF
--- a/wwwroot/js/navigation.js
+++ b/wwwroot/js/navigation.js
@@ -99,10 +99,11 @@ export function initNavigation({ body, root, app, toastsHost, scriptHost }) {
         }
         const incoming = doc.getElementById('toastsHost');
         if (!incoming) {
-            toastsHost.innerHTML = '';
+            toastsHost.replaceChildren();
             return;
         }
-        toastsHost.innerHTML = incoming.innerHTML;
+        const nodes = Array.from(incoming.childNodes, node => document.importNode(node, true));
+        toastsHost.replaceChildren(...nodes);
         executeSoftScripts(toastsHost);
     }
 


### PR DESCRIPTION
## Summary
- avoid using innerHTML when refreshing the toast host by importing incoming child nodes
- keep toast scripts executing after the DOM transfer while ensuring the host clears when empty

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d87a9bed2c832d842cdaf4731140a1