### PR TITLE
Add soft teardown cleanup for client pages

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -872,7 +872,14 @@
             }
 
             let closing = false;
-            const detachKeydown = handler => document.removeEventListener('keydown', handler);
+            const keydownController = new AbortController();
+            const detachKeydown = () =>
+            {
+              if (!keydownController.signal.aborted)
+              {
+                keydownController.abort();
+              }
+            };
             const close = () =>
             {
               if (closing)
@@ -880,7 +887,7 @@
                 return;
               }
               closing = true;
-              detachKeydown(onKeydown);
+              detachKeydown();
 
               const exit = panel ? animateSoftVisibility(panel, false) : null;
               if (exit && typeof exit.then === 'function')
@@ -902,7 +909,18 @@
               }
             };
 
-            document.addEventListener('keydown', onKeydown);
+            document.addEventListener('keydown', onKeydown, { signal: keydownController.signal });
+
+            const appRoot = document.getElementById('app');
+            if (appRoot)
+            {
+              const handleSoftTeardown = () =>
+              {
+                detachKeydown();
+                close();
+              };
+              appRoot.addEventListener('soft:teardown', handleSoftTeardown, { once: true });
+            }
 
             modal.querySelectorAll('[data-close-modal]')
                  .forEach(btn => btn.addEventListener('click', close));

--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -497,8 +497,23 @@
           const panes = document.querySelectorAll('.tab-pane');
 
           const prevEventsDocClick = window.__eventsDocClick;
-          if (typeof prevEventsDocClick === 'function') {
-            document.removeEventListener('click', prevEventsDocClick);
+          if (prevEventsDocClick)
+          {
+            try
+            {
+              if (typeof prevEventsDocClick.abort === 'function')
+              {
+                prevEventsDocClick.abort();
+              }
+              else if (typeof prevEventsDocClick === 'function')
+              {
+                document.removeEventListener('click', prevEventsDocClick);
+              }
+            }
+            catch (error)
+            {
+              console.error('Failed to detach previous events click handler:', error);
+            }
             delete window.__eventsDocClick;
           }
 
@@ -949,8 +964,30 @@
                 ddType.classList.add('hidden');
               }
             };
-            document.addEventListener('click', onDocumentClick);
-            window.__eventsDocClick = onDocumentClick;
+            const docClickController = new AbortController();
+            const docClickSignal = docClickController.signal;
+
+            document.addEventListener('click', onDocumentClick, { signal: docClickSignal });
+
+            const teardownRef = {
+              abort: () =>
+              {
+                docClickController.abort();
+                ddType?.classList.add('hidden');
+                if (window.__eventsDocClick === teardownRef)
+                {
+                  delete window.__eventsDocClick;
+                }
+              }
+            };
+
+            window.__eventsDocClick = teardownRef;
+
+            const appRoot = document.getElementById('app');
+            if (appRoot)
+            {
+              appRoot.addEventListener('soft:teardown', teardownRef.abort, { once: true });
+            }
 
             [inType,inFrom,inTo,inUser,inIp].forEach(el=> el?.addEventListener('keydown', ev=>{ if(ev.key==='Enter'){ ev.preventDefault(); load(); }}));
 

--- a/wwwroot/js/navigation.js
+++ b/wwwroot/js/navigation.js
@@ -265,6 +265,11 @@ export function initNavigation({ body, root, app, toastsHost, scriptHost }) {
         }
         runTeardowns();
         cancelAppAnimation(currentApp);
+        try {
+            currentApp.dispatchEvent(new CustomEvent('soft:teardown'));
+        } catch (error) {
+            console.error('Soft navigation teardown event failed:', error);
+        }
         currentApp.replaceWith(importedMain);
         currentApp = importedMain;
         executeSoftScripts(currentApp);


### PR DESCRIPTION
## Summary
- dispatch a `soft:teardown` event before replacing the current app during soft navigation swaps
- tie the client creation modal's global key handler to an AbortController and the soft teardown lifecycle
- manage the client details event dropdown listener with teardown-aware cleanup to avoid accumulating handlers

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d87b54f084832db4fcbde66275de24