### PR TITLE
Fix admin sidebar alignment

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -42,7 +42,7 @@
             @if (isAdmin)
             {
                 <aside class="md:w-64 md:flex-shrink-0">
-                    <div class="kc-card p-4 mb-4 md:mb-0 md:sticky md:top-6">
+                    <div class="kc-card p-4 mb-4 md:mb-0 md:sticky md:top-0">
                         <div class="text-xs uppercase tracking-wide text-slate-400 mb-3">Администрирование</div>
                         <nav class="flex flex-col gap-1" data-admin-nav>
                             <a asp-page="/Clients/Search" class='@LinkClass("/Clients/Search")'>


### PR DESCRIPTION
## Summary
- align the admin sidebar card with the main content header by removing the extra sticky offset

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d886042628832d827169ff94c10e30