### PR TITLE
Add dark theme style for kc-select-dark class

### DIFF
--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -138,6 +138,13 @@
     color: var(--kc-ink);
 }
 
+.kc-select-dark
+{
+    background-color: #0a0f18;
+    color: var(--kc-ink);
+    border: 1px solid var(--kc-border-strong);
+}
+
 
 /* inp-with-prefix */
 .prefix-wrap {


### PR DESCRIPTION
## Summary
- add a `.kc-select-dark` rule to the shared stylesheet so selects share the dark theme palette

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d92c041214832d90436e393ae433ad