### PR TITLE
Improve accessibility of client search input

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -20,7 +20,8 @@
 
         <div class="flex items-center gap-3 w-full md:w-auto">
             <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[260px] focus-within:border-white/20">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <label class="sr-only" for="clientFilter">Поиск клиентов</label>
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
                     <circle cx="11" cy="11" r="8" />
                     <path d="m21 21-4.3-4.3" />
                 </svg>


### PR DESCRIPTION
## Summary
- add a visually hidden label bound to the client search input so assistive tech announces it
- hide the decorative search icon SVG from screen readers to avoid duplicate announcements

## Testing
- `node <<'NODE' ...` (dom-accessibility-api accessible name check)


------
https://chatgpt.com/codex/tasks/task_e_68d92c124674832db12e6d567b374f03