### PR TITLE
Refactor aurora headers into reusable partial

### DIFF
--- a/Pages/Admin/Events.cshtml
+++ b/Pages/Admin/Events.cshtml
@@ -4,25 +4,17 @@
     ViewData["Title"] = "События";
 }
 
-<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-6">
-    <div class="absolute inset-0 pointer-events-none">
-        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(14,165,233,.55), rgba(59,130,246,.35))"></div>
-        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(45,212,191,.6), rgba(99,102,241,.35))"></div>
-    </div>
-
-    <div class="relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
-            <h3 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(59,130,246,0.25)]">
-                События
-            </h3>
-            <p class="text-slate-200/80 mt-2 text-sm max-w-2xl">
-                Просматривайте журнал действий Assistant и фильтруйте события по типу, пользователю и диапазону дат.
-            </p>
-        </div>
-    </div>
-</div>
+@await Html.PartialAsync("_AuroraHeader", new AuroraHeaderModel
+{
+    Title = "События",
+    HeadingTag = "h3",
+    ThemeClass = "aurora-sky-teal",
+    Classes = "p-5 md:p-6 relative overflow-hidden mb-6",
+    ContentClasses = "relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between",
+    TitleCssClass = "text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(59,130,246,0.25)]",
+    Subtitle = "Просматривайте журнал действий Assistant и фильтруйте события по типу, пользователю и диапазону дат.",
+    SubtitleCssClass = "text-slate-200/80 mt-2 text-sm max-w-2xl"
+})
 
 <script data-soft-nav>
     (() => {

--- a/Pages/Admin/ServiceRoleExclusions.cshtml
+++ b/Pages/Admin/ServiceRoleExclusions.cshtml
@@ -4,25 +4,17 @@
     ViewData["Title"] = "Список исключений";
 }
 
-<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-6">
-    <div class="absolute inset-0 pointer-events-none">
-        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(14,165,233,.55), rgba(59,130,246,.35))"></div>
-        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(45,212,191,.6), rgba(99,102,241,.35))"></div>
-    </div>
-
-    <div class="relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
-            <h3 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(59,130,246,0.25)]">
-                Список исключений
-            </h3>
-            <p class="text-slate-200/80 mt-2 text-sm max-w-2xl">
-                Управляйте клиентами Keycloak, для которых запрещено назначать сервисные роли в Assistant.
-            </p>
-        </div>
-    </div>
-</div>
+@await Html.PartialAsync("_AuroraHeader", new AuroraHeaderModel
+{
+    Title = "Список исключений",
+    HeadingTag = "h3",
+    ThemeClass = "aurora-sky-teal",
+    Classes = "p-5 md:p-6 relative overflow-hidden mb-6",
+    ContentClasses = "relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between",
+    TitleCssClass = "text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(59,130,246,0.25)]",
+    Subtitle = "Управляйте клиентами Keycloak, для которых запрещено назначать сервисные роли в Assistant.",
+    SubtitleCssClass = "text-slate-200/80 mt-2 text-sm max-w-2xl"
+})
 
 <section class="kc-card p-6 mb-6 space-y-5">
     <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">

--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -4,25 +4,16 @@
     ViewData["Title"] = "Назначение доступа к клиентам";
 }
 
-<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-5">
-    <div class="absolute inset-0 pointer-events-none">
-        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(14,165,233,.55), rgba(59,130,246,.35))"></div>
-        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(45,212,191,.6), rgba(99,102,241,.35))"></div>
-    </div>
-
-    <div class="relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
-            <h3 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(59,130,246,0.25)]">
-                Назначение доступа к клиентам
-            </h3>
-            <p class="text-slate-200/80 mt-2 text-sm max-w-2xl">
-                Выберите клиента Keycloak и пользователя домена, чтобы предоставить доступ к карточке клиента в Assistant.
-            </p>
-        </div>
-    </div>
-</div>
+@await Html.PartialAsync("_AuroraHeader", new AuroraHeaderModel
+{
+    Title = "Назначение доступа к клиентам",
+    HeadingTag = "h3",
+    ThemeClass = "aurora-sky-teal",
+    ContentClasses = "relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between",
+    TitleCssClass = "text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(59,130,246,0.25)]",
+    Subtitle = "Выберите клиента Keycloak и пользователя домена, чтобы предоставить доступ к карточке клиента в Assistant.",
+    SubtitleCssClass = "text-slate-200/80 mt-2 text-sm max-w-2xl"
+})
 
 <div class="grid gap-6 lg:grid-cols-2 items-start">
     <section id="clientSearchPanel" class="kc-card p-5" data-soft-transition="#clientSearchPanel,#selectedClientCard,#grantAccessPanel">

--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -6,23 +6,24 @@
 }
 
 <div class="space-y-5">
-    <!-- Хедер -->
-    <div class="kc-header p-5 md:p-6 relative overflow-hidden">
-        <div class="absolute inset-0 pointer-events-none">
-            <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-                 style="background: radial-gradient(60% 60% at 50% 50%, rgba(16,185,129,.6), rgba(59,130,246,.4))"></div>
-            <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-                 style="background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35))"></div>
-        </div>
-        <div class="relative flex items-center justify-between">
-            <div>
-                <a asp-page="/Index" class="text-slate-400 text-sm hover:text-slate-200">&larr; Back to Clients</a>
-                <h1 class="mt-1 text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]">Create client</h1>
-                <p class="text-slate-300 text-sm">Пошаговый мастер создания клиента Keycloak.</p>
-            </div>
-            <div class="text-slate-400 text-sm">Realm: <span class="text-slate-200" id="realmHeader">—</span></div>
-        </div>
-    </div>
+    @{
+        Func<dynamic, Microsoft.AspNetCore.Html.IHtmlContent> createHeaderLead = @<a asp-page="/Index" class="text-slate-400 text-sm hover:text-slate-200">&larr; Back to Clients</a>;
+        Func<dynamic, Microsoft.AspNetCore.Html.IHtmlContent> createHeaderRight = @<text>Realm: <span class="text-slate-200" id="realmHeader">—</span></text>;
+    }
+    @await Html.PartialAsync("_AuroraHeader", new AuroraHeaderModel
+    {
+        Title = "Create client",
+        HeadingTag = "h1",
+        ThemeClass = "aurora-green-indigo",
+        Classes = "p-5 md:p-6 relative overflow-hidden",
+        ContentClasses = "relative flex items-center justify-between",
+        TitleCssClass = "mt-1 text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]",
+        TitleLeadContent = createHeaderLead,
+        Subtitle = "Пошаговый мастер создания клиента Keycloak.",
+        SubtitleCssClass = "text-slate-300 text-sm",
+        RightContent = createHeaderRight,
+        RightContainerClasses = "text-slate-400 text-sm"
+    })
 
     <!-- Stepper -->
     <div class="kc-card md:max-w-[1000px] mx-auto">

--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -15,36 +15,34 @@
 }
 
 
-<!-- Хедер -->
-<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-5">
-    <div class="flex items-center">
+@{
+    Func<dynamic, Microsoft.AspNetCore.Html.IHtmlContent> detailsHeaderLead = @<div class="flex items-center">
         <a href="@Model.BackUrl" class="text-slate-400 text-sm hover:text-slate-200">&larr; Back to Clients</a>
         <div class="ml-auto text-slate-400 text-sm">Realm: <span class="text-slate-200">@realm</span></div>
-    </div>
-    <div class="absolute inset-0 pointer-events-none">
-        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(16,185,129,.6), rgba(59,130,246,.4))"></div>
-        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35))"></div>
-    </div>
-
-    <div class="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div>
-            <h1 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]">@clientId</h1>
-        </div>
-        <div class="flex items-center gap-2">
-            <span class="text-md text-slate-200">Status</span>
-            <label class="kc-switch inline-flex items-center">
-                <input type="checkbox" id="swEnabled" @(enabled ? "checked" : "") />
-                <span class="track"><span class="dot"></span></span>
-            </label>
-            <span id="lblEnabled"
-                  class="inline-flex items-center rounded-full px-2 py-1 text-xs border border-white/10 @(enabled ? "bg-emerald-500/20 text-emerald-200" : "bg-rose-500/20 text-rose-200")">
-                @((enabled) ? "Enabled" : "Disabled")
-            </span>
-        </div>
-    </div>
-</div>
+    </div>;
+    Func<dynamic, Microsoft.AspNetCore.Html.IHtmlContent> detailsHeaderRight = @<text>
+        <span class="text-md text-slate-200">Status</span>
+        <label class="kc-switch inline-flex items-center">
+            <input type="checkbox" id="swEnabled" @(enabled ? "checked" : "") />
+            <span class="track"><span class="dot"></span></span>
+        </label>
+        <span id="lblEnabled"
+              class="inline-flex items-center rounded-full px-2 py-1 text-xs border border-white/10 @(enabled ? "bg-emerald-500/20 text-emerald-200" : "bg-rose-500/20 text-rose-200")">
+            @((enabled) ? "Enabled" : "Disabled")
+        </span>
+    </text>;
+}
+@await Html.PartialAsync("_AuroraHeader", new AuroraHeaderModel
+{
+    Title = clientId,
+    HeadingTag = "h1",
+    ThemeClass = "aurora-green-indigo",
+    ContentClasses = "relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between",
+    TitleCssClass = "text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]",
+    LeadContent = detailsHeaderLead,
+    RightContent = detailsHeaderRight,
+    RightContainerClasses = "flex items-center gap-2"
+})
 
 <!-- Вкладки -->
 <div class="flex flex-wrap gap-2 mb-4" role="tablist" aria-label="Client tabs">

--- a/Pages/Clients/Search.cshtml
+++ b/Pages/Clients/Search.cshtml
@@ -4,43 +4,37 @@
     ViewData["Title"] = "Поиск клиентов";
 }
 
-<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-5">
-    <div class="absolute inset-0 pointer-events-none">
-        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(16,185,129,.6), rgba(59,130,246,.4))"></div>
-        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35))"></div>
-    </div>
-
-    <div class="relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
-            <h3 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]">
-                Поиск клиентов
-            </h3>
-            <p class="text-slate-200/80 mt-2 text-sm max-w-xl">
-                Выполните поиск по всем реалмам Keycloak. Результаты отфильтруются по введённому clientId.
-            </p>
-        </div>
-
-        <div class="flex items-center gap-3 w-full md:w-auto">
-            <form method="get" class="flex items-center gap-3 w-full md:w-auto"
-                  data-soft-transition="#clientsResults">
-                <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[320px] focus-within:border-white/20">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="11" cy="11" r="8" />
-                        <path d="m21 21-4.3-4.3" />
-                    </svg>
-                    <input name="q" value="@Model.Q" placeholder="Ищем по всем реалмам..."
-                           class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-                </div>
-                <button type="submit" class="btn-primary whitespace-nowrap">Найти</button>
-            </form>
-            <a asp-page="/Clients/Create" class="btn-primary whitespace-nowrap">
-                Создать клиента
-            </a>
-        </div>
-    </div>
-</div>
+@{
+    Func<dynamic, Microsoft.AspNetCore.Html.IHtmlContent> searchHeaderRight = @<text>
+        <form method="get" class="flex items-center gap-3 w-full md:w-auto"
+              data-soft-transition="#clientsResults">
+            <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[320px] focus-within:border-white/20">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="11" cy="11" r="8" />
+                    <path d="m21 21-4.3-4.3" />
+                </svg>
+                <input name="q" value="@Model.Q" placeholder="Ищем по всем реалмам..."
+                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
+            </div>
+            <button type="submit" class="btn-primary whitespace-nowrap">Найти</button>
+        </form>
+        <a asp-page="/Clients/Create" class="btn-primary whitespace-nowrap">
+            Создать клиента
+        </a>
+    </text>;
+}
+@await Html.PartialAsync("_AuroraHeader", new AuroraHeaderModel
+{
+    Title = "Поиск клиентов",
+    HeadingTag = "h3",
+    ThemeClass = "aurora-green-indigo",
+    ContentClasses = "relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between",
+    TitleCssClass = "text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]",
+    Subtitle = "Выполните поиск по всем реалмам Keycloak. Результаты отфильтруются по введённому clientId.",
+    SubtitleCssClass = "text-slate-200/80 mt-2 text-sm max-w-xl",
+    RightContent = searchHeaderRight,
+    RightContainerClasses = "flex items-center gap-3 w-full md:w-auto"
+})
 
 <div id="clientsResults" class="space-y-5">
     @if (string.IsNullOrEmpty(Model.Q))

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -4,37 +4,32 @@
     ViewData["Title"] = "Clients";
 }
 
-<!-- Шапка как на Details/Index — стеклянная, с аурами -->
-<div class="kc-header p-5 md:p-6 relative overflow-hidden mb-5">
-    <div class="absolute inset-0 pointer-events-none">
-        <div class="glow-blob absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(16,185,129,.6), rgba(59,130,246,.4))"></div>
-        <div class="glow-blob absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"
-             style="background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35))"></div>
-    </div>
-
-    <div class="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <h3 class="text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]">
-            Мои клиенты
-        </h3>
-
-        <div class="flex items-center gap-3 w-full md:w-auto">
-            <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[260px] focus-within:border-white/20">
-                <label class="sr-only" for="clientFilter">Поиск клиентов</label>
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
-                    <circle cx="11" cy="11" r="8" />
-                    <path d="m21 21-4.3-4.3" />
-                </svg>
-                <input id="clientFilter" placeholder="Поиск клиентов..."
-                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-            </div>
-
-            <a asp-page="/Clients/Create" class="btn-primary">
-                Создать клиента
-            </a>
+@{
+    Func<dynamic, Microsoft.AspNetCore.Html.IHtmlContent> indexHeaderRight = @<text>
+        <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[260px] focus-within:border-white/20">
+            <label class="sr-only" for="clientFilter">Поиск клиентов</label>
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
+                <circle cx="11" cy="11" r="8" />
+                <path d="m21 21-4.3-4.3" />
+            </svg>
+            <input id="clientFilter" placeholder="Поиск клиентов..."
+                   class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
         </div>
-    </div>
-</div>
+        <a asp-page="/Clients/Create" class="btn-primary">
+            Создать клиента
+        </a>
+    </text>;
+}
+@await Html.PartialAsync("_AuroraHeader", new AuroraHeaderModel
+{
+    Title = "Мои клиенты",
+    HeadingTag = "h3",
+    ThemeClass = "aurora-green-indigo",
+    ContentClasses = "relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between",
+    TitleCssClass = "text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]",
+    RightContent = indexHeaderRight,
+    RightContainerClasses = "flex items-center gap-3 w-full md:w-auto"
+})
 @if (User.IsInRole("assistant-admin"))
 {
     <div class="kc-card mb-5 p-5 text-sm text-slate-300/90">

--- a/Pages/Shared/AuroraHeaderModel.cs
+++ b/Pages/Shared/AuroraHeaderModel.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.AspNetCore.Html;
+
+namespace Assistant.Pages.Shared;
+
+public class AuroraHeaderModel
+{
+    public string Title { get; set; } = string.Empty;
+
+    public string HeadingTag { get; set; } = "h3";
+
+    public string ThemeClass { get; set; } = "aurora-green-indigo";
+
+    public string Classes { get; set; } = "p-5 md:p-6 relative overflow-hidden mb-5";
+
+    public string ContentClasses { get; set; } = "relative flex flex-col gap-4 md:flex-row md:items-center";
+
+    public string TitleCssClass { get; set; } = "text-3xl md:text-4xl text-white tracking-tight drop-shadow-[0_6px_18px_rgba(99,102,241,0.25)]";
+
+    public Func<dynamic, IHtmlContent>? TitleLeadContent { get; set; }
+
+    public Func<dynamic, IHtmlContent>? LeadContent { get; set; }
+
+    public string? Subtitle { get; set; }
+
+    public Func<dynamic, IHtmlContent>? SubtitleContent { get; set; }
+
+    public string SubtitleCssClass { get; set; } = "text-slate-200/80 mt-2 text-sm max-w-xl";
+
+    public Func<dynamic, IHtmlContent>? RightContent { get; set; }
+
+    public string RightContainerClasses { get; set; } = "flex items-center gap-3 w-full md:w-auto";
+
+    public bool HasSubtitle => !string.IsNullOrWhiteSpace(Subtitle) || SubtitleContent != null;
+}

--- a/Pages/Shared/_AuroraHeader.cshtml
+++ b/Pages/Shared/_AuroraHeader.cshtml
@@ -1,0 +1,85 @@
+@model AuroraHeaderModel
+@using Assistant.Pages.Shared
+@using System
+@{
+    var themeClass = string.IsNullOrWhiteSpace(Model.ThemeClass) ? "aurora-green-indigo" : Model.ThemeClass;
+    var rootClasses = string.IsNullOrWhiteSpace(Model.Classes)
+        ? "p-5 md:p-6 relative overflow-hidden mb-5"
+        : Model.Classes;
+    var contentClasses = string.IsNullOrWhiteSpace(Model.ContentClasses)
+        ? "relative flex flex-col gap-4 md:flex-row md:items-center"
+        : Model.ContentClasses;
+    if (Model.RightContent != null && !contentClasses.Contains("md:justify-between", StringComparison.Ordinal))
+    {
+        contentClasses += " md:justify-between";
+    }
+
+    var titleCss = string.IsNullOrWhiteSpace(Model.TitleCssClass)
+        ? "text-3xl md:text-4xl text-white tracking-tight"
+        : Model.TitleCssClass;
+    var headingTag = string.IsNullOrWhiteSpace(Model.HeadingTag) ? "h3" : Model.HeadingTag.ToLowerInvariant();
+    var subtitleCss = string.IsNullOrWhiteSpace(Model.SubtitleCssClass)
+        ? "text-slate-200/80 mt-2 text-sm max-w-xl"
+        : Model.SubtitleCssClass;
+    var rightContainerClasses = string.IsNullOrWhiteSpace(Model.RightContainerClasses)
+        ? "flex items-center gap-3 w-full md:w-auto"
+        : Model.RightContainerClasses;
+}
+<div class="kc-header @themeClass @rootClasses">
+    @if (Model.LeadContent != null)
+    {
+        <div class="relative mb-3">
+            @Model.LeadContent.Invoke(null)
+        </div>
+    }
+    <div class="absolute inset-0 pointer-events-none">
+        <div class="glow-blob aurora-blob aurora-blob-primary absolute -top-12 left-8 h-40 w-40 rounded-full blur-[70px] opacity-60"></div>
+        <div class="glow-blob aurora-blob aurora-blob-secondary absolute -bottom-16 right-10 h-44 w-44 rounded-full blur-[80px] opacity-40"></div>
+    </div>
+
+    <div class="@contentClasses">
+        <div>
+            @if (Model.TitleLeadContent != null)
+            {
+                @Model.TitleLeadContent.Invoke(null)
+            }
+
+            @switch (headingTag)
+            {
+                case "h1":
+                    <h1 class="@titleCss">@Model.Title</h1>
+                    break;
+                case "h2":
+                    <h2 class="@titleCss">@Model.Title</h2>
+                    break;
+                case "h4":
+                    <h4 class="@titleCss">@Model.Title</h4>
+                    break;
+                default:
+                    <h3 class="@titleCss">@Model.Title</h3>
+                    break;
+            }
+
+            @if (Model.HasSubtitle)
+            {
+                if (Model.SubtitleContent != null)
+                {
+                    <div class="@subtitleCss">
+                        @Model.SubtitleContent.Invoke(null)
+                    </div>
+                }
+                else if (!string.IsNullOrWhiteSpace(Model.Subtitle))
+                {
+                    <p class="@subtitleCss">@Model.Subtitle</p>
+                }
+            }
+        </div>
+
+        @if (Model.RightContent != null)
+        {
+            <div class="@rightContainerClasses">
+                @Model.RightContent.Invoke(null)
+            </div>
+        }
+    </div>
+</div>

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using Assistant
+@using Assistant.Pages.Shared
 @namespace Assistant.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -66,6 +66,27 @@
     }
 }
 
+
+.aurora-blob {
+    background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35));
+}
+
+.kc-header.aurora-green-indigo .aurora-blob-primary {
+    background: radial-gradient(60% 60% at 50% 50%, rgba(16,185,129,.6), rgba(59,130,246,.4));
+}
+
+.kc-header.aurora-green-indigo .aurora-blob-secondary {
+    background: radial-gradient(60% 60% at 50% 50%, rgba(99,102,241,.65), rgba(45,212,191,.35));
+}
+
+.kc-header.aurora-sky-teal .aurora-blob-primary {
+    background: radial-gradient(60% 60% at 50% 50%, rgba(14,165,233,.55), rgba(59,130,246,.35));
+}
+
+.kc-header.aurora-sky-teal .aurora-blob-secondary {
+    background: radial-gradient(60% 60% at 50% 50%, rgba(45,212,191,.6), rgba(99,102,241,.35));
+}
+
 .glow-blob {
     animation: kc-floatGlow 6s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary
- add a shared `_AuroraHeader` partial with a backing model to centralize header rendering and configurable slots
- extract aurora gradient backgrounds into named utility classes so themes can be switched without inline styles
- replace repeated header markup across client and admin pages with the reusable component

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d92e4b70dc832db1f00b1a92f33d42