### PR TITLE
Create reusable flash toast partial

### DIFF
--- a/Pages/Admin/ServiceRoleExclusions.cshtml
+++ b/Pages/Admin/ServiceRoleExclusions.cshtml
@@ -214,24 +214,20 @@
 @section Toasts {
     @if (TempData["FlashOk"] is string ok)
     {
-        <div class="kc-toast kc-toast-success" id="flashToastOk" role="alert">
-            <div class="kc-toast-icon">✓</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">@Html.Raw(ok)</div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>setTimeout(() => document.getElementById('flashToastOk')?.remove(), 10000);</script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Success,
+            MessageHtml = Html.Raw(ok),
+            Id = "flashToastOk"
+        })
     }
     @if (TempData["FlashError"] is string err)
     {
-        <div class="kc-toast kc-toast-error" id="flashToastError" role="alert">
-            <div class="kc-toast-icon">!</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">@err</div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>setTimeout(() => document.getElementById('flashToastError')?.remove(), 10000);</script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Error,
+            Message = err,
+            Id = "flashToastError"
+        })
     }
 }

--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -381,24 +381,20 @@
 @section Toasts {
     @if (TempData["FlashOk"] is string ok)
     {
-        <div class="kc-toast kc-toast-success" id="flashToastOk" role="alert">
-            <div class="kc-toast-icon">✓</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">@Html.Raw(ok)</div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>setTimeout(() => document.getElementById('flashToastOk')?.remove(), 10000);</script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Success,
+            MessageHtml = Html.Raw(ok),
+            Id = "flashToastOk"
+        })
     }
     @if (TempData["FlashError"] is string err)
     {
-        <div class="kc-toast kc-toast-error" id="flashToastError" role="alert">
-            <div class="kc-toast-icon">!</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">@err</div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>setTimeout(() => document.getElementById('flashToastError')?.remove(), 10000);</script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Error,
+            Message = err,
+            Id = "flashToastError"
+        })
     }
 }

--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -355,18 +355,13 @@
 @section Toasts {
     @if (!ViewContext.ViewData.ModelState.IsValid)
     {
-        <div class="kc-toast kc-toast-error" id="formErrorToast" role="alert">
-            <div class="kc-toast-icon">!</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">Не удалось создать клиента</div>
-                <div asp-validation-summary="All" class="validation-summary-errors"></div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть"
-                    onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>
-            setTimeout(() => document.getElementById('formErrorToast')?.remove(), 10000);
-        </script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Error,
+            Message = "Не удалось создать клиента",
+            Id = "formErrorToast",
+            IncludeValidationSummary = true
+        })
     }
 }
 

--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -464,25 +464,21 @@
 @section Toasts {
     @if (TempData["FlashOk"] is string ok)
     {
-        <div class="kc-toast kc-toast-success" id="flashToastOk" role="alert">
-            <div class="kc-toast-icon">✓</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">@Html.Raw(ok)</div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>setTimeout(() => document.getElementById('flashToastOk')?.remove(), 10000);</script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Success,
+            MessageHtml = Html.Raw(ok),
+            Id = "flashToastOk"
+        })
     }
     @if (TempData["FlashError"] is string err)
     {
-        <div class="kc-toast kc-toast-error" id="flashToastError" role="alert">
-            <div class="kc-toast-icon">!</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">@err</div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>setTimeout(() => document.getElementById('flashToastError')?.remove(), 10000);</script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Error,
+            Message = err,
+            Id = "flashToastError"
+        })
     }
 }
 

--- a/Pages/Clients/Search.cshtml
+++ b/Pages/Clients/Search.cshtml
@@ -52,14 +52,11 @@
 @section Toasts {
     @if (TempData["FlashOk"] is string flash)
     {
-        <div class="kc-toast kc-toast-success" id="flashToast" role="alert">
-            <div class="kc-toast-icon">✓</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">@Html.Raw(flash)</div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть"
-                    onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>setTimeout(() => document.getElementById('flashToast')?.remove(), 10000);</script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Success,
+            MessageHtml = Html.Raw(flash),
+            Id = "flashToast"
+        })
     }
 }

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -64,14 +64,11 @@
 @section Toasts {
     @if (TempData["FlashOk"] is string flash)
     {
-        <div class="kc-toast kc-toast-success" id="flashToast" role="alert">
-            <div class="kc-toast-icon">✓</div>
-            <div class="kc-toast-body">
-                <div class="kc-toast-title">@Html.Raw(flash)</div>
-            </div>
-            <button type="button" class="kc-toast-close" aria-label="Закрыть"
-                    onclick="this.closest('.kc-toast').remove()">×</button>
-        </div>
-        <script data-soft-nav>setTimeout(() => document.getElementById('flashToast')?.remove(), 10000);</script>
+        @await Html.PartialAsync("_FlashToast", new FlashToastModel
+        {
+            Type = FlashToastType.Success,
+            MessageHtml = Html.Raw(flash),
+            Id = "flashToast"
+        })
     }
 }

--- a/Pages/Shared/FlashToastModel.cs
+++ b/Pages/Shared/FlashToastModel.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Html;
+
+namespace Assistant.Pages.Shared;
+
+public enum FlashToastType
+{
+    Success,
+    Error
+}
+
+public sealed class FlashToastModel
+{
+    public FlashToastType Type { get; init; }
+
+    public string? Message { get; init; }
+
+    public IHtmlContent? MessageHtml { get; init; }
+
+    public string? Id { get; init; }
+
+    public int TimeoutMs { get; init; } = 10_000;
+
+    public bool IncludeValidationSummary { get; init; }
+}

--- a/Pages/Shared/_FlashToast.cshtml
+++ b/Pages/Shared/_FlashToast.cshtml
@@ -1,0 +1,57 @@
+@model FlashToastModel
+@using System
+
+@{
+    var toastId = string.IsNullOrWhiteSpace(Model.Id)
+        ? $"toast_{Guid.NewGuid():N}"
+        : Model.Id!;
+    var hasTimeout = Model.TimeoutMs > 0;
+    var toastClass = Model.Type == FlashToastType.Success ? "kc-toast-success" : "kc-toast-error";
+    var icon = Model.Type == FlashToastType.Success ? "✓" : "!";
+}
+
+<div class="kc-toast @toastClass" id="@toastId" role="alert"@(hasTimeout ? $" data-timeout=\"{Model.TimeoutMs}\"" : null)>
+    <div class="kc-toast-icon">@icon</div>
+    <div class="kc-toast-body">
+        <div class="kc-toast-title">
+            @if (Model.MessageHtml is not null)
+            {
+                @Model.MessageHtml
+            }
+            else if (!string.IsNullOrEmpty(Model.Message))
+            {
+                @Model.Message
+            }
+        </div>
+        @if (Model.IncludeValidationSummary)
+        {
+            <div asp-validation-summary="All" class="validation-summary-errors"></div>
+        }
+    </div>
+    <button type="button" class="kc-toast-close" aria-label="Закрыть" onclick="this.closest('.kc-toast')?.remove()">×</button>
+</div>
+
+@if (!ViewContext.HttpContext.Items.ContainsKey("__FlashToastScriptAdded"))
+{
+    ViewContext.HttpContext.Items["__FlashToastScriptAdded"] = true;
+    <script data-soft-nav>
+        (() => {
+            const selector = '.kc-toast[data-timeout]';
+            const processedAttr = 'data-timeout-initialized';
+            const applyTimeout = toast => {
+                if (!toast || toast.hasAttribute(processedAttr)) return;
+                toast.setAttribute(processedAttr, 'true');
+                const timeout = parseInt(toast.getAttribute('data-timeout'), 10);
+                if (!Number.isFinite(timeout) || timeout <= 0) return;
+                window.setTimeout(() => toast.remove(), timeout);
+            };
+
+            const processAll = () => {
+                document.querySelectorAll(selector).forEach(applyTimeout);
+            };
+
+            processAll();
+            document.addEventListener('DOMContentLoaded', processAll);
+        })();
+    </script>
+}


### PR DESCRIPTION
## Summary
- add a shared `_FlashToast` partial and backing model to standardize toast markup, icons, and auto-dismiss logic
- update pages that previously duplicated toast markup to render the shared component and support validation summary display when needed

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d93223ad38832d95f7d26fa4273897