### PR TITLE
Refactor search forms to share search input partial

### DIFF
--- a/Pages/Admin/ServiceRoleExclusions.cshtml
+++ b/Pages/Admin/ServiceRoleExclusions.cshtml
@@ -1,4 +1,5 @@
 @page
+@using Assistant.Pages.Shared
 @model Assistant.Pages.Admin.ServiceRoleExclusionsModel
 @{
     ViewData["Title"] = "Список исключений";
@@ -31,17 +32,17 @@
     </div>
 
     <form method="get" class="flex flex-col gap-3 md:flex-row md:items-center">
-        <div class="relative flex-1">
-            <span class="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400/70">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m1.35-4.65a6 6 0 1 1-12 0 6 6 0 0 1 12 0Z" />
-                </svg>
-            </span>
-            <input type="text" name="SearchTerm" value="@Model.SearchTerm" placeholder="Введите clientId или его часть"
-                   minlength="@Model.SearchMinLength"
-                   class="w-full rounded-xl border border-white/10 bg-white/5 py-2.5 pl-11 pr-4 text-sm text-slate-100 placeholder:text-slate-400 focus:border-white/20 focus:outline-none focus:ring-0" />
-            <input type="hidden" name="SearchPage" value="1" />
-        </div>
+        @await Html.PartialAsync("_SearchInput", new SearchInputModel
+        {
+            Name = "SearchTerm",
+            Value = Model.SearchTerm,
+            Placeholder = "Введите clientId или его часть",
+            MinLength = Model.SearchMinLength,
+            WidthClasses = "flex-1",
+            IconAbsolute = true,
+            InputType = "text"
+        })
+        <input type="hidden" name="SearchPage" value="1" />
         <button type="submit" class="btn-primary whitespace-nowrap md:self-stretch">Найти</button>
     </form>
 

--- a/Pages/Admin/UserClients.cshtml
+++ b/Pages/Admin/UserClients.cshtml
@@ -1,4 +1,5 @@
 @page
+@using Assistant.Pages.Shared
 @model Assistant.Pages.Admin.UserClientsModel
 @{
     ViewData["Title"] = "Назначение доступа к клиентам";
@@ -26,15 +27,13 @@
         </div>
 
         <form method="get" class="flex flex-col gap-3" data-soft-transition="#clientSearchPanel,#selectedClientCard,#grantAccessPanel">
-            <div class="kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <circle cx="11" cy="11" r="8" />
-                    <path d="m21 21-4.3-4.3" />
-                </svg>
-                <input name="clientQuery" value="@Model.ClientQuery" placeholder="Введите clientId"
-                       minlength="3"
-                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-            </div>
+            @await Html.PartialAsync("_SearchInput", new SearchInputModel
+            {
+                Name = "clientQuery",
+                Value = Model.ClientQuery,
+                Placeholder = "Введите clientId",
+                MinLength = Model.MinimumQueryLength
+            })
             <input type="hidden" name="clientPage" value="1" />
             <input type="hidden" name="userPage" value="@Model.UserPage" />
             <input type="hidden" name="assignmentPage" value="@Model.AssignmentPage" />
@@ -137,15 +136,13 @@
         </div>
 
         <form method="get" class="flex flex-col gap-3">
-            <div class="kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <circle cx="11" cy="11" r="8" />
-                    <path d="m21 21-4.3-4.3" />
-                </svg>
-                <input name="userQuery" value="@Model.UserQuery" placeholder="username, email или ФИО"
-                       minlength="3"
-                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-            </div>
+            @await Html.PartialAsync("_SearchInput", new SearchInputModel
+            {
+                Name = "userQuery",
+                Value = Model.UserQuery,
+                Placeholder = "username, email или ФИО",
+                MinLength = Model.MinimumQueryLength
+            })
             <input type="hidden" name="userPage" value="1" />
             <input type="hidden" name="clientPage" value="@Model.ClientPage" />
             <input type="hidden" name="clientQuery" value="@Model.ClientQuery" />

--- a/Pages/Clients/Search.cshtml
+++ b/Pages/Clients/Search.cshtml
@@ -1,4 +1,5 @@
 @page
+@using Assistant.Pages.Shared
 @model Assistant.Pages.Clients.SearchModel
 @{
     ViewData["Title"] = "Поиск клиентов";
@@ -8,14 +9,13 @@
     Func<dynamic, Microsoft.AspNetCore.Html.IHtmlContent> searchHeaderRight = @<text>
         <form method="get" class="flex items-center gap-3 w-full md:w-auto"
               data-soft-transition="#clientsResults">
-            <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[320px] focus-within:border-white/20">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <circle cx="11" cy="11" r="8" />
-                    <path d="m21 21-4.3-4.3" />
-                </svg>
-                <input name="q" value="@Model.Q" placeholder="Ищем по всем реалмам..."
-                       class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-            </div>
+            @await Html.PartialAsync("_SearchInput", new SearchInputModel
+            {
+                Name = "q",
+                Value = Model.Q,
+                Placeholder = "Ищем по всем реалмам...",
+                WidthClasses = "w-full md:w-[320px]"
+            })
             <button type="submit" class="btn-primary whitespace-nowrap">Найти</button>
         </form>
         <a asp-page="/Clients/Create" class="btn-primary whitespace-nowrap">

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using Assistant.Pages.Shared
 @model Assistant.Pages.IndexModel
 @{
     ViewData["Title"] = "Clients";
@@ -6,15 +7,14 @@
 
 @{
     Func<dynamic, Microsoft.AspNetCore.Html.IHtmlContent> indexHeaderRight = @<text>
-        <div class="flex items-center gap-2 kc-input rounded-xl px-3 py-2 text-sm w-full md:w-[260px] focus-within:border-white/20">
-            <label class="sr-only" for="clientFilter">Поиск клиентов</label>
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
-                <circle cx="11" cy="11" r="8" />
-                <path d="m21 21-4.3-4.3" />
-            </svg>
-            <input id="clientFilter" placeholder="Поиск клиентов..."
-                   class="bg-transparent outline-none placeholder:text-slate-400 w-full" />
-        </div>
+        @await Html.PartialAsync("_SearchInput", new SearchInputModel
+        {
+            Id = "clientFilter",
+            Name = "clientFilter",
+            Placeholder = "Поиск клиентов...",
+            WidthClasses = "w-full md:w-[260px]",
+            Label = "Поиск клиентов"
+        })
         <a asp-page="/Clients/Create" class="btn-primary">
             Создать клиента
         </a>

--- a/Pages/Shared/SearchInputModel.cs
+++ b/Pages/Shared/SearchInputModel.cs
@@ -1,0 +1,28 @@
+namespace Assistant.Pages.Shared;
+
+public class SearchInputModel
+{
+    public string? Id { get; set; }
+
+    public string? Name { get; set; }
+
+    public string Placeholder { get; set; } = string.Empty;
+
+    public string? Value { get; set; }
+
+    public int? MinLength { get; set; }
+
+    public bool IconAbsolute { get; set; }
+
+    public string WidthClasses { get; set; } = "w-full";
+
+    public string ContainerClasses { get; set; } = string.Empty;
+
+    public string InputClasses { get; set; } = string.Empty;
+
+    public string Label { get; set; } = string.Empty;
+
+    public string LabelCssClass { get; set; } = "sr-only";
+
+    public string InputType { get; set; } = "search";
+}

--- a/Pages/Shared/_SearchInput.cshtml
+++ b/Pages/Shared/_SearchInput.cshtml
@@ -1,0 +1,72 @@
+@model Assistant.Pages.Shared.SearchInputModel
+@{
+    var id = string.IsNullOrWhiteSpace(Model.Id)
+        ? (string.IsNullOrWhiteSpace(Model.Name) ? null : Model.Name)
+        : Model.Id;
+    var widthClasses = string.IsNullOrWhiteSpace(Model.WidthClasses)
+        ? "w-full"
+        : Model.WidthClasses;
+    var containerClasses = Model.IconAbsolute
+        ? $"relative {widthClasses} {Model.ContainerClasses}".Trim()
+        : $"kc-input rounded-xl px-3 py-2 text-sm focus-within:border-white/20 flex items-center gap-2 {widthClasses} {Model.ContainerClasses}".Trim();
+    var inputClasses = string.IsNullOrWhiteSpace(Model.InputClasses)
+        ? (Model.IconAbsolute
+            ? "w-full rounded-xl border border-white/10 bg-white/5 py-2.5 pl-11 pr-4 text-sm text-slate-100 placeholder:text-slate-400 focus:border-white/20 focus:outline-none focus:ring-0"
+            : "bg-transparent outline-none placeholder:text-slate-400 w-full")
+        : Model.InputClasses;
+}
+@if (!string.IsNullOrWhiteSpace(Model.Label) && !string.IsNullOrWhiteSpace(id))
+{
+    <label for="@id" class="@Model.LabelCssClass">@Model.Label</label>
+}
+@if (Model.IconAbsolute)
+{
+    <div class="@containerClasses">
+        <span class="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400/70">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true" focusable="false">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m1.35-4.65a6 6 0 1 1-12 0 6 6 0 0 1 12 0Z" />
+            </svg>
+        </span>
+        <input type="@Model.InputType"
+               @if (!string.IsNullOrWhiteSpace(id))
+               {
+                   <text>id="@id"</text>
+               }
+               @if (!string.IsNullOrWhiteSpace(Model.Name))
+               {
+                   <text> name="@Model.Name"</text>
+               }
+               value="@(Model.Value ?? string.Empty)"
+               placeholder="@Model.Placeholder"
+               class="@inputClasses"
+               @if (Model.MinLength.HasValue)
+               {
+                   <text> minlength="@Model.MinLength.Value"</text>
+               } />
+    </div>
+}
+else
+{
+    <div class="@containerClasses">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+        </svg>
+        <input type="@Model.InputType"
+               @if (!string.IsNullOrWhiteSpace(id))
+               {
+                   <text>id="@id"</text>
+               }
+               @if (!string.IsNullOrWhiteSpace(Model.Name))
+               {
+                   <text> name="@Model.Name"</text>
+               }
+               value="@(Model.Value ?? string.Empty)"
+               placeholder="@Model.Placeholder"
+               class="@inputClasses"
+               @if (Model.MinLength.HasValue)
+               {
+                   <text> minlength="@Model.MinLength.Value"</text>
+               } />
+    </div>
+}


### PR DESCRIPTION
## Summary
- add a reusable search input model and partial that supports inline and absolute icon variants with configurable attributes
- refactor search forms on the clients index, global search, admin assignment, and exclusions pages to use the shared component for consistent markup

## Testing
- dotnet build *(fails: `dotnet` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d93ce3cfdc832db98cc2b9f31ded7d