### PR TITLE
Use DOM-safe chip rendering for clients pages

### DIFF
--- a/Pages/Clients/Create.cshtml
+++ b/Pages/Clients/Create.cshtml
@@ -611,9 +611,18 @@
             arr.forEach((v, idx) => {
               const span = document.createElement('span');
               span.className = 'chip';
-              span.innerHTML = `${v} <button type="button" title="Remove">×</button>`;
-              span.querySelector('button')
-                  .addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(listEl, arr); });
+              span.textContent = v;
+
+              const space = document.createTextNode(' ');
+              const button = document.createElement('button');
+              button.type = 'button';
+              button.title = 'Remove';
+              button.textContent = '×';
+
+              button.addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(listEl, arr); });
+
+              span.appendChild(space);
+              span.appendChild(button);
               listEl.appendChild(span);
             });
           }
@@ -691,9 +700,18 @@
             arr.forEach((v, idx) => {
               const span = document.createElement('span');
               span.className = 'chip';
-              span.innerHTML = `${v} <button type="button" title="Remove">×</button>`;
-              span.querySelector('button')
-                  .addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(listEl, arr); });
+              span.textContent = v;
+
+              const space = document.createTextNode(' ');
+              const button = document.createElement('button');
+              button.type = 'button';
+              button.title = 'Remove';
+              button.textContent = '×';
+
+              button.addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(listEl, arr); });
+
+              span.appendChild(space);
+              span.appendChild(button);
               listEl.appendChild(span);
             });
           }

--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -589,8 +589,18 @@
             arr.forEach((v, idx)=>{
               const chip = document.createElement('span');
               chip.className = 'kc-chip';
-              chip.innerHTML = `${v} <button type="button" title="Remove">×</button>`;
-              chip.querySelector('button').addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(el, arr); });
+              chip.textContent = v;
+
+              const space = document.createTextNode(' ');
+              const button = document.createElement('button');
+              button.type = 'button';
+              button.title = 'Remove';
+              button.textContent = '×';
+
+              button.addEventListener('click', ()=>{ arr.splice(idx,1); renderChips(el, arr); });
+
+              chip.appendChild(space);
+              chip.appendChild(button);
               el.appendChild(chip);
             });
           }


### PR DESCRIPTION
## Summary
- render chips on the client creation page using text nodes and explicit remove buttons instead of innerHTML
- apply the same DOM-safe chip rendering to the client details page

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9426dd48c832d96a07b1142f32ac5