### PR TITLE
Add client and realm index for user client deletions

### DIFF
--- a/Services/UserClientsRepository.cs
+++ b/Services/UserClientsRepository.cs
@@ -38,10 +38,16 @@ public class UserClientsRepository
         await using (var cmd = new NpgsqlCommand(sql, conn))
             await cmd.ExecuteNonQueryAsync(ct);
 
-        const string indexSql =
+        const string identityIndexSql =
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_user_clients_identity ON user_clients(username, client_id, realm);";
 
-        await using (var idx = new NpgsqlCommand(indexSql, conn))
+        await using (var idx = new NpgsqlCommand(identityIndexSql, conn))
+            await idx.ExecuteNonQueryAsync(ct);
+
+        const string clientRealmIndexSql =
+            "CREATE INDEX IF NOT EXISTS ix_user_clients_client_realm ON user_clients(client_id, realm);";
+
+        await using (var idx = new NpgsqlCommand(clientRealmIndexSql, conn))
             await idx.ExecuteNonQueryAsync(ct);
 
         _initialized = true;


### PR DESCRIPTION
## Summary
- ensure the user clients repository creates a non-unique index on `(client_id, realm)` to support targeted deletes

## Testing
- not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d9784dcf58832d920a3fa932e2d4d8