### PR TITLE
Use GetRange for client paging

### DIFF
--- a/Pages/ClientsPageModel.cs
+++ b/Pages/ClientsPageModel.cs
@@ -65,6 +65,12 @@ public abstract class ClientsPageModel : PageModel
     {
         TotalPages = Math.Max(1, (int)Math.Ceiling(list.Count / (double)PageSize));
         PageNumber = Math.Clamp(pageNumber, 1, TotalPages);
-        Clients = list.Skip((PageNumber - 1) * PageSize).Take(PageSize).ToList();
+        var startIndex = (PageNumber - 1) * PageSize;
+        var remainingItems = Math.Max(0, list.Count - startIndex);
+        var count = Math.Min(PageSize, remainingItems);
+
+        Clients = count > 0
+            ? list.GetRange(startIndex, count)
+            : [];
     }
 }


### PR DESCRIPTION
## Summary
- calculate page boundaries for client lists using explicit start index and count
- retrieve the current page slice via List.GetRange while keeping empty results safe

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68da5d336290832db116551e825819b7