### PR TITLE
Align user client audit logging with event palette

### DIFF
--- a/Pages/Admin/UserClients.cshtml.cs
+++ b/Pages/Admin/UserClients.cshtml.cs
@@ -380,7 +380,7 @@ public sealed class UserClientsModel : PageModel
             await _repo.RemoveForUserAsync(username, clientId, realm, ct);
             var actor = GetCurrentActorLogin();
             await AuditAssignmentChangeAsync(
-                "CLIENT:REVOKE",
+                "USER:REVOKE",
                 actor,
                 realm,
                 clientId,
@@ -443,12 +443,8 @@ public sealed class UserClientsModel : PageModel
             ? $"{normalizedClientId}"
             : $"{clientName}";
         var normalizedOperation = operationType;
-        string details = normalizedOperation switch
-        {
-            "GRANT" => $"Пользователю {normalizedTargetUser} присвоено: {clientDisplay}",
-            "REVOKE" => $"Пользователю {normalizedTargetUser} удалены клиенты: {clientDisplay}",
-            _ => $"Пользователю {normalizedTargetUser} обновлены клиенты: {clientDisplay}"
-        };
+        var actionSuffix = ExtractOperationSuffix(normalizedOperation);
+        var details = FormatAssignmentChangeDetails(actionSuffix, normalizedTargetUser, clientDisplay);
 
         return _logs.LogAsync(
             operationType,
@@ -457,5 +453,34 @@ public sealed class UserClientsModel : PageModel
             normalizedTargetUser,
             details,
             ct);
+    }
+
+    private static string ExtractOperationSuffix(string normalizedOperation)
+    {
+        if (string.IsNullOrWhiteSpace(normalizedOperation))
+        {
+            return normalizedOperation;
+        }
+
+        var separatorIndex = normalizedOperation.LastIndexOf(':');
+        if (separatorIndex < 0 || separatorIndex == normalizedOperation.Length - 1)
+        {
+            return normalizedOperation;
+        }
+
+        return normalizedOperation[(separatorIndex + 1)..];
+    }
+
+    protected virtual string FormatAssignmentChangeDetails(
+        string actionSuffix,
+        string normalizedTargetUser,
+        string clientDisplay)
+    {
+        return actionSuffix switch
+        {
+            "GRANT" => $"Пользователю {normalizedTargetUser} присвоено: {clientDisplay}",
+            "REVOKE" => $"Пользователю {normalizedTargetUser} удалены клиенты: {clientDisplay}",
+            _ => $"Пользователю {normalizedTargetUser} обновлены клиенты: {clientDisplay}"
+        };
     }
 }

--- a/tests/Assistant.Tests/Assistant.Tests.csproj
+++ b/tests/Assistant.Tests/Assistant.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Assistant.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Assistant.Tests/UserClientsModelTests.cs
+++ b/tests/Assistant.Tests/UserClientsModelTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using System.Runtime.Serialization;
+using Assistant.Pages.Admin;
+using Assistant.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Assistant.Tests;
+
+public sealed class UserClientsModelTests
+{
+    [Fact]
+    public void FormatAssignmentChangeDetails_ForGrant_ReturnsExpectedMessage()
+    {
+        var model = CreateModel();
+        var result = InvokeFormatAssignmentChangeDetails(model, "GRANT", "test-user", "test-client");
+
+        Assert.Equal("Пользователю test-user присвоено: test-client", result);
+    }
+
+    [Fact]
+    public void FormatAssignmentChangeDetails_ForRevoke_ReturnsExpectedMessage()
+    {
+        var model = CreateModel();
+        var result = InvokeFormatAssignmentChangeDetails(model, "REVOKE", "another-user", "client-display");
+
+        Assert.Equal("Пользователю another-user удалены клиенты: client-display", result);
+    }
+
+    private static UserClientsModel CreateModel()
+    {
+        var uninitializedRepository = (ApiLogRepository)FormatterServices.GetUninitializedObject(typeof(ApiLogRepository));
+
+        return new UserClientsModel(
+            realms: null!,
+            clients: null!,
+            users: null!,
+            repo: null!,
+            logs: uninitializedRepository,
+            logger: NullLogger<UserClientsModel>.Instance);
+    }
+
+    private static string InvokeFormatAssignmentChangeDetails(
+        UserClientsModel model,
+        string actionSuffix,
+        string normalizedTargetUser,
+        string clientDisplay)
+    {
+        var method = typeof(UserClientsModel).GetMethod(
+            name: "FormatAssignmentChangeDetails",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        return (string)method!.Invoke(model, new object[] { actionSuffix, normalizedTargetUser, clientDisplay })!;
+    }
+}


### PR DESCRIPTION
## Summary
- align revoke audit events with the USER operation namespace used by the admin event palette
- centralize audit detail formatting on the page model and normalize the operation suffix lookup
- add xUnit coverage for grant and revoke formatting to guard the generated messages

## Testing
- `dotnet test` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da6916693c832da6c2ef8d315fa8d6