### PR TITLE
Enhance client card styling

### DIFF
--- a/Pages/Shared/_ClientsList.cshtml
+++ b/Pages/Shared/_ClientsList.cshtml
@@ -26,20 +26,23 @@ else if (Model.Clients.Any())
             var subtitle = string.Equals(displayName, c.ClientId, StringComparison.OrdinalIgnoreCase)
                 ? $"Realm: {c.Realm}"
                 : displayName;
+            var initialSource = string.IsNullOrWhiteSpace(displayName)
+                ? c.ClientId
+                : displayName;
+            var clientInitial = string.IsNullOrWhiteSpace(initialSource)
+                ? "?"
+                : char.ToUpperInvariant(initialSource.Trim()[0]).ToString();
+            var hasEnvironments = envList.Any();
 
             <a asp-page="/Clients/Details" asp-route-realm="@c.Realm" asp-route-clientId="@c.ClientId"
                asp-route-returnUrl="@returnUrl"
                class="block group client-card"
-                data-search="@($"{c.ClientId} {c.Realm} {displayName}")">
-                <div class="kc-card kc-card--hover p-5 h-44 overflow-hidden transition relative">
-                    <!-- лёгкая подсветка по ховеру -->
-                    <div class="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition duration-500"
-                         style="background:
-                                         radial-gradient(480px 140px at 60% 18%, rgba(45,212,191,.12), transparent 70%),
-                                         radial-gradient(520px 180px at 10% 100%, rgba(99,102,241,.10), transparent 75%)"></div>
+               data-search="@($"{c.ClientId} {c.Realm} {displayName}")">
+                <div class="kc-card kc-card--hover client-card__surface p-5 min-h-[210px] overflow-hidden transition relative">
+                    <span class="client-card__glare" aria-hidden="true"></span>
 
                     <!-- Контур-линия окружений (внизу карточки) -->
-                    @if (envList.Any())
+                    @if (hasEnvironments)
                     {
                         <div class="absolute inset-x-0 top-0 h-[4px] flex overflow-hidden">
                             @foreach (var e in envList)
@@ -51,23 +54,40 @@ else if (Model.Clients.Any())
 
                     <div class="relative h-full flex flex-col">
                         <!-- Заголовок + статус -->
-                        <div class="flex items-start justify-between">
-                            <div class="text-slate-100 font-semibold text-lg truncate">@c.ClientId</div>
-                            <span class="inline-flex items-center rounded-full px-2 py-1 text-[11px] border border-white/10 @(c.Enabled ? "bg-emerald-500/20 text-emerald-200" : "bg-rose-500/20 text-rose-200")">
+                        <div class="flex items-start justify-between gap-3">
+                            <div class="flex items-start gap-3 min-w-0">
+                                <div class="client-card__avatar" aria-hidden="true">@clientInitial</div>
+                                <div class="min-w-0">
+                                    <div class="text-slate-100 font-semibold text-lg truncate">@c.ClientId</div>
+                                    <div class="client-card__realm">@c.Realm</div>
+                                </div>
+                            </div>
+                            <span class="client-card__status @(c.Enabled ? "client-card__status--enabled" : "client-card__status--disabled")">
                                 @(c.Enabled ? "Enabled" : "Disabled")
                             </span>
                         </div>
 
                         <!-- Описание -->
-                        <div class="text-slate-300/90 text-[15px] mt-1 line-clamp-2">
+                        <div class="client-card__subtitle mt-3 line-clamp-2">
                             @subtitle
                         </div>
 
                         <!-- Окружения (чипы) -->
-                        <div class="mt-auto pt-3 flex items-center gap-2 flex-wrap">
-                            @foreach (var e in envList)
+                        <div class="mt-auto">
+                            <div class="client-card__divider mt-5 mb-3"></div>
+                            @if (hasEnvironments)
                             {
-                                <span class="kc-chip">@e</span>
+                                <div class="client-card__envs-label">Окружения</div>
+                                <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                    @foreach (var e in envList)
+                                    {
+                                        <span class="kc-chip client-card__chip">@e</span>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="client-card__empty">Нет окружений</div>
                             }
                         </div>
                     </div>

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -120,8 +120,228 @@
     opacity: .75;
 }
 
+/* ===== Client Cards ===== */
+.client-card {
+    position: relative;
+    display: block;
+    padding: 1px;
+    border-radius: 1.2rem;
+    background: linear-gradient(140deg, rgba(59,130,246,.25), rgba(124,58,237,.22) 45%, rgba(16,185,129,.2));
+    transition: transform .35s ease, filter .35s ease;
+    isolation: isolate;
+    z-index: 0;
+}
+
+.client-card::before {
+    content: "";
+    position: absolute;
+    inset: -2px;
+    border-radius: inherit;
+    background:
+        radial-gradient(65% 65% at 24% 18%, rgba(59,130,246,.35), transparent 70%),
+        radial-gradient(55% 55% at 82% 4%, rgba(14,165,233,.28), transparent 70%);
+    opacity: 0;
+    transition: opacity .45s ease;
+    z-index: -1;
+}
+
+.client-card:hover {
+    transform: translateY(-6px);
+    filter: drop-shadow(0 20px 44px rgba(76,29,149,.28));
+}
+
+.client-card:hover::before {
+    opacity: .85;
+}
+
+.client-card__surface {
+    position: relative;
+    border-radius: calc(1.2rem - 2px);
+    background: linear-gradient(180deg, rgba(12,18,30,.96), rgba(12,20,33,.9));
+    border: 1px solid rgba(148,163,184,.2);
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.02), 0 12px 30px rgba(2,6,23,.45);
+    overflow: hidden;
+}
+
+.client-card__surface::before {
+    content: "";
+    position: absolute;
+    inset: -1px;
+    border-radius: inherit;
+    background:
+        radial-gradient(120% 90% at 12% -20%, rgba(59,130,246,.35), transparent 70%),
+        radial-gradient(120% 80% at 110% -10%, rgba(236,72,153,.16), transparent 70%);
+    opacity: .4;
+    transition: opacity .45s ease;
+    pointer-events: none;
+}
+
+.client-card__surface::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background-image:
+        linear-gradient(120deg, rgba(148,163,184,.12) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(148,163,184,.08) 1px, transparent 1px);
+    background-size: 38px 38px;
+    opacity: 0;
+    transition: opacity .45s ease;
+    mix-blend-mode: screen;
+    pointer-events: none;
+}
+
+.client-card:hover .client-card__surface::before {
+    opacity: .6;
+}
+
+.client-card:hover .client-card__surface::after {
+    opacity: .25;
+}
+
+.client-card__glare {
+    position: absolute;
+    inset: 60% -35% -40% -35%;
+    background: radial-gradient(70% 90% at 50% 0%, rgba(45,212,191,.18), transparent 70%);
+    opacity: 0;
+    transform: translateY(12px);
+    transition: transform .45s ease, opacity .45s ease;
+    pointer-events: none;
+}
+
+.client-card:hover .client-card__glare {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.client-card__avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 1rem;
+    background: linear-gradient(135deg, rgba(129,140,248,.95), rgba(56,189,248,.88));
+    box-shadow: 0 14px 28px rgba(76,29,149,.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: .06em;
+    color: #fff;
+    text-transform: uppercase;
+    transition: transform .35s ease, box-shadow .35s ease;
+}
+
+.client-card:hover .client-card__avatar {
+    transform: translateY(-2px) scale(1.05);
+    box-shadow: 0 18px 36px rgba(76,29,149,.45);
+}
+
+.client-card__realm {
+    margin-top: .35rem;
+    font-size: .68rem;
+    letter-spacing: .18em;
+    text-transform: uppercase;
+    color: rgba(148,163,184,.72);
+}
+
+.client-card__subtitle {
+    color: rgba(226,232,240,.82);
+    font-size: .95rem;
+    line-height: 1.45;
+    transition: color .35s ease;
+}
+
+.client-card:hover .client-card__subtitle {
+    color: rgba(226,232,240,.92);
+}
+
+.client-card__status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: .35rem .8rem;
+    font-size: .68rem;
+    font-weight: 600;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    border-radius: 9999px;
+    border: 1px solid rgba(255,255,255,.16);
+    background: rgba(30,41,59,.65);
+    box-shadow: 0 12px 26px rgba(15,23,42,.55);
+    transition: transform .35s ease, box-shadow .35s ease, color .35s ease, border-color .35s ease, background .35s ease;
+}
+
+.client-card__status--enabled {
+    color: rgba(190,242,100,.92);
+    border-color: rgba(45,212,191,.35);
+    background: linear-gradient(135deg, rgba(34,197,94,.18), rgba(16,185,129,.2));
+    box-shadow: 0 14px 32px rgba(16,185,129,.24);
+}
+
+.client-card__status--disabled {
+    color: rgba(254,202,202,.92);
+    border-color: rgba(248,113,113,.35);
+    background: linear-gradient(135deg, rgba(239,68,68,.18), rgba(190,18,60,.22));
+    box-shadow: 0 14px 32px rgba(248,113,113,.2);
+}
+
+.client-card:hover .client-card__status {
+    transform: translateY(-1px);
+}
+
+.client-card__divider {
+    height: 1px;
+    width: 100%;
+    border-radius: 9999px;
+    background: linear-gradient(90deg, transparent, rgba(148,163,184,.25), transparent);
+    opacity: .75;
+    transition: opacity .35s ease, background .35s ease;
+}
+
+.client-card:hover .client-card__divider {
+    opacity: 1;
+    background: linear-gradient(90deg, rgba(56,189,248,.35), rgba(124,58,237,.55), rgba(16,185,129,.35));
+}
+
+.client-card__envs-label {
+    font-size: .7rem;
+    letter-spacing: .22em;
+    text-transform: uppercase;
+    color: rgba(148,163,184,.64);
+    transition: color .35s ease;
+}
+
+.client-card:hover .client-card__envs-label {
+    color: rgba(226,232,240,.78);
+}
+
+.client-card__chip {
+    position: relative;
+    background: rgba(15,23,42,.72);
+    border: 1px solid rgba(148,163,184,.24);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.05), 0 6px 20px rgba(2,6,23,.35);
+    font-size: .7rem;
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    padding: .4rem .65rem;
+    transition: border-color .35s ease, color .35s ease, box-shadow .35s ease;
+}
+
+.client-card:hover .client-card__chip {
+    border-color: rgba(96,165,250,.45);
+    color: rgba(226,232,240,.9);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.12), 0 10px 24px rgba(30,64,175,.35);
+}
+
+.client-card__empty {
+    font-size: .68rem;
+    letter-spacing: .2em;
+    text-transform: uppercase;
+    color: rgba(148,163,184,.58);
+}
+
 /* ===== Inputs / Selects ===== */
-.kc-input 
+.kc-input
 {
     background: #0a0f18 !important;
     border: 1px solid var(--kc-border-strong);


### PR DESCRIPTION
## Summary
- enrich the client list card markup with avatars, realm labels, and environment summaries
- add a bespoke visual treatment for client cards with gradient borders, hover glows, and refined status chips

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da73a0d56c832da272313a307596df