### PR TITLE
Enhance client cards styling

### DIFF
--- a/Pages/Shared/_ClientsList.cshtml
+++ b/Pages/Shared/_ClientsList.cshtml
@@ -1,3 +1,5 @@
+@using System
+@using System.Linq
 @model Assistant.Pages.ClientsPageModel
 
 @{
@@ -23,51 +25,113 @@ else if (Model.Clients.Any())
             // один раз материализуем, чтобы не итерировать несколько раз
             var envList = Model.Envs(c.Realm).ToList();
             var displayName = c.DisplayName;
-            var subtitle = string.Equals(displayName, c.ClientId, StringComparison.OrdinalIgnoreCase)
-                ? $"Realm: {c.Realm}"
-                : displayName;
+            var hasCustomName = !string.Equals(displayName, c.ClientId, StringComparison.OrdinalIgnoreCase);
+            var customName = hasCustomName ? displayName : null;
+            var baseForInitials = hasCustomName ? displayName : c.ClientId;
+            baseForInitials ??= string.Empty;
+            var trimmed = baseForInitials.Trim();
+            var parts = trimmed.Split(new[] { ' ', '-', '_', '.', '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var initials = string.Concat(parts.Take(2).Select(part => char.ToUpperInvariant(part[0])));
+
+            if (string.IsNullOrWhiteSpace(initials))
+            {
+                var fallback = trimmed.Length > 0 ? trimmed : (c.ClientId ?? string.Empty);
+                fallback = fallback.Trim();
+
+                if (fallback.Length == 0)
+                {
+                    fallback = "KC";
+                }
+
+                initials = fallback.Substring(0, System.Math.Min(2, fallback.Length)).ToUpperInvariant();
+            }
 
             <a asp-page="/Clients/Details" asp-route-realm="@c.Realm" asp-route-clientId="@c.ClientId"
                asp-route-returnUrl="@returnUrl"
                class="block group client-card"
                 data-search="@($"{c.ClientId} {c.Realm} {displayName}")">
-                <div class="kc-card kc-card--hover p-5 h-44 overflow-hidden transition relative">
-                    <!-- лёгкая подсветка по ховеру -->
-                    <div class="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition duration-500"
-                         style="background:
-                                         radial-gradient(480px 140px at 60% 18%, rgba(45,212,191,.12), transparent 70%),
-                                         radial-gradient(520px 180px at 10% 100%, rgba(99,102,241,.10), transparent 75%)"></div>
-
-                    <!-- Контур-линия окружений (внизу карточки) -->
+                <span class="client-card__halo" aria-hidden="true"></span>
+                <div class="kc-card kc-card--hover client-card__body">
                     @if (envList.Any())
                     {
-                        <div class="absolute inset-x-0 top-0 h-[4px] flex overflow-hidden">
+                        <div class="client-card__env-stripe" aria-hidden="true">
                             @foreach (var e in envList)
                             {
-                                <span class="flex-1 h-full bg-gradient-to-r @Model.EnvBarGradient(e)"></span>
+                                <span class="client-card__env-segment bg-gradient-to-r @Model.EnvBarGradient(e)"></span>
                             }
                         </div>
                     }
 
-                    <div class="relative h-full flex flex-col">
-                        <!-- Заголовок + статус -->
-                        <div class="flex items-start justify-between">
-                            <div class="text-slate-100 font-semibold text-lg truncate">@c.ClientId</div>
-                            <span class="inline-flex items-center rounded-full px-2 py-1 text-[11px] border border-white/10 @(c.Enabled ? "bg-emerald-500/20 text-emerald-200" : "bg-rose-500/20 text-rose-200")">
-                                @(c.Enabled ? "Enabled" : "Disabled")
+                    <div class="client-card__background" aria-hidden="true"></div>
+                    <div class="client-card__glare" aria-hidden="true"></div>
+
+                    <div class="client-card__content">
+                        <div class="client-card__header">
+                            <div class="client-card__avatar" aria-hidden="true">
+                                <span class="client-card__avatar-text">@initials</span>
+                            </div>
+
+                            <div class="client-card__title-block">
+                                <div class="client-card__id" title="@c.ClientId">@c.ClientId</div>
+                                @if (!string.IsNullOrEmpty(customName))
+                                {
+                                    <div class="client-card__name" title="@customName">@customName</div>
+                                }
+                            </div>
+
+                            <span class="client-card__status @(c.Enabled ? "is-enabled" : "is-disabled")">
+                                <span class="client-card__status-dot" aria-hidden="true"></span>
+                                @(c.Enabled ? "Активен" : "Отключен")
                             </span>
                         </div>
 
-                        <!-- Описание -->
-                        <div class="text-slate-300/90 text-[15px] mt-1 line-clamp-2">
-                            @subtitle
+                        <div class="client-card__realm-row">
+                            <span class="client-card__realm-chip" title="Realm">
+                                <svg class="client-card__realm-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                                    <path d="M3 7.5L10 3l7 4.5v5L10 17l-7-4.5v-5Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"></path>
+                                    <path d="M3 7.5l7 4.5 7-4.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" opacity=".7"></path>
+                                    <path d="M10 17V12" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" opacity=".7"></path>
+                                </svg>
+                                <span>@c.Realm</span>
+                            </span>
                         </div>
 
-                        <!-- Окружения (чипы) -->
-                        <div class="mt-auto pt-3 flex items-center gap-2 flex-wrap">
-                            @foreach (var e in envList)
+                        <div class="client-card__flows" role="list" aria-label="Активные потоки">
+                            <span class="client-card__flow @(c.FlowStandard ? "is-active" : "is-muted")" role="listitem" title="Authorization Code Flow">
+                                <svg viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                                    <rect x="4" y="8" width="12" height="8" rx="2.5" stroke="currentColor" stroke-width="1.4" opacity=".85"></rect>
+                                    <path d="M7 8V6.5a3 3 0 116 0V8" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"></path>
+                                    <circle cx="10" cy="12" r="1" fill="currentColor"></circle>
+                                </svg>
+                                <span>Auth Code</span>
+                            </span>
+                            <span class="client-card__flow @(c.FlowService ? "is-active" : "is-muted")" role="listitem" title="Client Credentials Flow">
+                                <svg viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                                    <rect x="3" y="4" width="14" height="4.5" rx="1.8" stroke="currentColor" stroke-width="1.4" opacity=".85"></rect>
+                                    <rect x="3" y="10" width="14" height="4.5" rx="1.8" stroke="currentColor" stroke-width="1.4" opacity=".65"></rect>
+                                    <path d="M6 6.25h1.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"></path>
+                                    <path d="M6 12.25h1.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" opacity=".7"></path>
+                                    <path d="M10 12.25h4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" opacity=".7"></path>
+                                </svg>
+                                <span>Service</span>
+                            </span>
+                        </div>
+
+                        <div class="client-card__footer">
+                            @if (envList.Any())
                             {
-                                <span class="kc-chip">@e</span>
+                                <div class="client-card__envs" aria-label="Окружения">
+                                    @foreach (var e in envList)
+                                    {
+                                        <span class="kc-chip">@e</span>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="client-card__envs client-card__envs--empty" aria-label="Окружения">
+                                    <span class="kc-chip kc-chip--ghost">Окружения не указаны</span>
+                                </div>
                             }
                         </div>
                     </div>

--- a/wwwroot/css/kc.css
+++ b/wwwroot/css/kc.css
@@ -120,8 +120,278 @@
     opacity: .75;
 }
 
+/* ===== Client Card Enhancements ===== */
+.client-card {
+    position: relative;
+    display: block;
+    border-radius: 1rem;
+    transition: transform .25s ease, filter .25s ease;
+}
+
+.client-card:hover {
+    transform: translateY(-4px);
+}
+
+.client-card:focus-visible {
+    outline: none;
+}
+
+.client-card:focus-visible .client-card__body {
+    border-color: rgba(129,140,248,.45);
+    box-shadow: 0 0 0 2px rgba(99,102,241,.35), 0 18px 60px rgba(0,0,0,.6);
+}
+
+.client-card__body {
+    position: relative;
+    padding: 1.35rem;
+    overflow: hidden;
+    display: flex;
+    min-height: 15.25rem;
+    transition: border-color .3s ease;
+}
+
+.client-card__halo {
+    position: absolute;
+    inset: -3px;
+    border-radius: 1.2rem;
+    background: radial-gradient(120% 120% at 50% 0%, rgba(45,212,191,.18), rgba(124,58,237,.08));
+    filter: blur(16px);
+    opacity: 0;
+    transition: opacity .45s ease, transform .45s ease;
+    transform: scale(.96);
+    pointer-events: none;
+}
+
+.group:hover .client-card__halo,
+.client-card:focus-visible .client-card__halo {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.client-card__background {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(80% 60% at 80% 0%, rgba(59,130,246,.20), transparent 65%),
+                radial-gradient(80% 60% at 0% 100%, rgba(16,185,129,.16), transparent 70%);
+    opacity: 0;
+    transition: opacity .45s ease;
+}
+
+.group:hover .client-card__background,
+.client-card:focus-visible .client-card__background {
+    opacity: 1;
+}
+
+.client-card__glare {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(255,255,255,.08), transparent 55%);
+    mix-blend-mode: screen;
+    opacity: .35;
+    pointer-events: none;
+}
+
+.client-card__env-stripe {
+    position: absolute;
+    inset: 0;
+    top: 0;
+    height: 5px;
+    display: flex;
+    overflow: hidden;
+    z-index: 2;
+}
+
+.client-card__env-segment {
+    flex: 1 1 auto;
+}
+
+.client-card__content {
+    position: relative;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+    width: 100%;
+}
+
+.client-card__header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.9rem;
+    justify-content: space-between;
+}
+
+.client-card__avatar {
+    width: 46px;
+    height: 46px;
+    border-radius: 1rem;
+    background: linear-gradient(135deg, rgba(79,70,229,.65), rgba(14,165,233,.5));
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    color: #f8fafc;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    box-shadow: 0 10px 25px rgba(15,23,42,.45);
+    flex-shrink: 0;
+}
+
+.client-card__avatar-text {
+    font-size: .95rem;
+}
+
+.client-card__title-block {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.client-card__id {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #e2e8f0;
+    letter-spacing: .01em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.client-card__name {
+    margin-top: 0.2rem;
+    font-size: .82rem;
+    color: rgba(203,213,225,.82);
+    letter-spacing: .04em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.client-card__status {
+    display: inline-flex;
+    align-items: center;
+    gap: .45rem;
+    padding: .35rem .75rem;
+    border-radius: 9999px;
+    border: 1px solid rgba(148,163,184,.25);
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .12em;
+    white-space: nowrap;
+    background: rgba(148,163,184,.12);
+    color: rgba(226,232,240,.8);
+    transition: background .3s ease, color .3s ease, border-color .3s ease;
+}
+
+.client-card__status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 9999px;
+    background: currentColor;
+    box-shadow: 0 0 0 3px rgba(255,255,255,.08);
+}
+
+.client-card__status.is-enabled {
+    color: rgba(134,239,172,.92);
+    border-color: rgba(34,197,94,.35);
+    background: linear-gradient(135deg, rgba(34,197,94,.22), rgba(13,148,136,.18));
+}
+
+.client-card__status.is-disabled {
+    color: rgba(254,202,202,.9);
+    border-color: rgba(248,113,113,.25);
+    background: linear-gradient(135deg, rgba(248,113,113,.18), rgba(239,68,68,.12));
+}
+
+.client-card__realm-row {
+    display: flex;
+    align-items: center;
+}
+
+.client-card__realm-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: .45rem;
+    padding: .4rem .85rem;
+    border-radius: 9999px;
+    background: rgba(15,23,42,.6);
+    border: 1px solid rgba(148,163,184,.25);
+    color: rgba(191,219,254,.88);
+    font-size: .75rem;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+}
+
+.client-card__realm-icon {
+    width: 16px;
+    height: 16px;
+}
+
+.client-card__flows {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: .5rem;
+}
+
+.client-card__flow {
+    display: inline-flex;
+    align-items: center;
+    gap: .45rem;
+    padding: .35rem .85rem;
+    border-radius: .9rem;
+    border: 1px solid rgba(148,163,184,.25);
+    background: rgba(148,163,184,.12);
+    color: rgba(226,232,240,.82);
+    font-size: .7rem;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    transition: background .3s ease, color .3s ease, border-color .3s ease, box-shadow .3s ease;
+}
+
+.client-card__flow svg {
+    width: 16px;
+    height: 16px;
+    stroke: currentColor;
+}
+
+.client-card__flow.is-active {
+    background: linear-gradient(135deg, rgba(59,130,246,.22), rgba(56,189,248,.18));
+    border-color: rgba(59,130,246,.35);
+    box-shadow: 0 8px 22px rgba(59,130,246,.18);
+}
+
+.client-card__flow.is-muted {
+    opacity: .6;
+}
+
+.client-card__footer {
+    margin-top: auto;
+    padding-top: .75rem;
+    border-top: 1px solid rgba(148,163,184,.12);
+}
+
+.client-card__envs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    align-items: center;
+}
+
+.client-card__envs .kc-chip {
+    background: rgba(30,41,59,.65);
+    border-color: rgba(148,163,184,.4);
+    color: rgba(226,232,240,.85);
+    box-shadow: 0 6px 16px rgba(15,23,42,.35);
+}
+
+.client-card__envs--empty .kc-chip {
+    border-style: dashed;
+    color: rgba(148,163,184,.85);
+    background: rgba(30,41,59,.4);
+}
+
 /* ===== Inputs / Selects ===== */
-.kc-input 
+.kc-input
 {
     background: #0a0f18 !important;
     border: 1px solid var(--kc-border-strong);
@@ -216,6 +486,12 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
+}
+
+.kc-chip--ghost {
+    background: rgba(30,41,59,.35);
+    border: 1px dashed rgba(148,163,184,.5);
+    color: rgba(203,213,225,.75);
 }
 
     .kc-chip button, .chip button {


### PR DESCRIPTION
## Summary
- restyled the client list card markup to include avatars, flow badges, realm chips, and improved empty state messaging
- added extensive CSS for the redesigned cards with hover halos, gradients, and refined chip treatments

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da76868b14832da3a5d1691283556d