### PR TITLE
Improve service role exclusion cache invalidation

### DIFF
--- a/KeyCloak/ClientsService.cs
+++ b/KeyCloak/ClientsService.cs
@@ -2,6 +2,7 @@ using Assistant.KeyCloak.Models;
 using Assistant.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.Options;
 using System;
 using System.Net;
@@ -15,7 +16,7 @@ public sealed class ClientsService
 {
     private readonly IHttpClientFactory _factory;
     private readonly AdminApiOptions _opt;
-    private readonly ServiceRoleExclusionsRepository _exclusions;
+    private readonly IServiceRoleExclusionsRepository _exclusions;
     private readonly ApiLogRepository _logs;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IMemoryCache _cache;
@@ -97,7 +98,7 @@ public sealed class ClientsService
     public ClientsService(
         IHttpClientFactory factory,
         IOptions<AdminApiOptions> opt,
-        ServiceRoleExclusionsRepository exclusions,
+        IServiceRoleExclusionsRepository exclusions,
         ApiLogRepository logs,
         IHttpContextAccessor httpContextAccessor,
         IMemoryCache cache)
@@ -240,14 +241,17 @@ public sealed class ClientsService
         first = Math.Max(0, first);
         max = Math.Clamp(max <= 0 ? 20 : max, 1, 200);
 
-        var cacheKey = BuildClientSearchCacheKey(realm, query, first, max);
+        var excluded = await _exclusions.GetAllAsync(ct);
+        var exclusionsVersion = _exclusions.GetVersion();
+        var exclusionChangeToken = _exclusions.CreateChangeToken();
+
+        var cacheKey = BuildClientSearchCacheKey(realm, query, first, max, exclusionsVersion);
         if (_cache.TryGetValue(cacheKey, out ClientShort[] cachedClients))
         {
             return new List<ClientShort>(cachedClients);
         }
 
         var http = CreateAdminClient();
-        var excluded = await _exclusions.GetAllAsync(ct);
 
         var (urlExactNew, urlExactLegacy) =
             BuildAdminUrls(realm, $"clients?clientId={UR(query)}&briefRepresentation=true");
@@ -269,7 +273,7 @@ public sealed class ClientsService
             var filteredExact = FilterExcluded(mappedExact, excluded);
             if (filteredExact.Count > 0)
             {
-                return CacheSearchResult(cacheKey, filteredExact);
+                return CacheSearchResult(cacheKey, filteredExact, exclusionChangeToken);
             }
         }
 
@@ -288,24 +292,24 @@ public sealed class ClientsService
             .ToList();
 
         var filtered = FilterExcluded(mapped, excluded);
-        return CacheSearchResult(cacheKey, filtered);
+        return CacheSearchResult(cacheKey, filtered, exclusionChangeToken);
 
         static ClientShort MapClient(ClientRep c) => new(c.Id ?? string.Empty, c.ClientId ?? string.Empty);
 
-        List<ClientShort> CacheSearchResult(string key, List<ClientShort> result)
+        List<ClientShort> CacheSearchResult(string key, List<ClientShort> result, IChangeToken changeToken)
         {
             var snapshot = result.ToArray();
             _cache.Set(key, snapshot, new MemoryCacheEntryOptions
             {
                 AbsoluteExpirationRelativeToNow = ClientSearchCacheDuration
-            });
+            }.AddExpirationToken(changeToken));
 
             return new List<ClientShort>(snapshot);
         }
     }
 
-    private static string BuildClientSearchCacheKey(string realm, string query, int first, int max)
-        => $"kc:clients:search:{realm}:{first}:{max}:{query}";
+    private static string BuildClientSearchCacheKey(string realm, string query, int first, int max, long version)
+        => $"kc:clients:search:{realm}:{first}:{max}:{query}:v{version}";
 
     private async Task<ClientShort?> GetClientShortByClientIdAsync(string realm, string clientId, CancellationToken ct)
     {

--- a/Pages/Admin/ServiceRoleExclusions.cshtml.cs
+++ b/Pages/Admin/ServiceRoleExclusions.cshtml.cs
@@ -17,7 +17,7 @@ namespace Assistant.Pages.Admin;
 [Authorize(Roles = "assistant-admin")]
 public sealed class ServiceRoleExclusionsModel : PageModel
 {
-    private readonly ServiceRoleExclusionsRepository _repository;
+    private readonly IServiceRoleExclusionsRepository _repository;
     private readonly ApiLogRepository _logs;
     private readonly RealmsService _realms;
     private readonly ClientsService _clients;
@@ -32,7 +32,7 @@ public sealed class ServiceRoleExclusionsModel : PageModel
     private const int RealmSearchConcurrencyLimit = 4;
 
     public ServiceRoleExclusionsModel(
-        ServiceRoleExclusionsRepository repository,
+        IServiceRoleExclusionsRepository repository,
         ApiLogRepository logs,
         RealmsService realms,
         ClientsService clients,

--- a/Pages/Clients/Create.cshtml.cs
+++ b/Pages/Clients/Create.cshtml.cs
@@ -22,7 +22,7 @@ public class CreateModel : PageModel
     private readonly RealmsService _realms;
     private readonly ClientsService _clients;
     private readonly UserClientsRepository _repo;
-    private readonly ServiceRoleExclusionsRepository _exclusions;
+    private readonly IServiceRoleExclusionsRepository _exclusions;
     private readonly ConfluenceWikiService _wiki;
     private readonly ClientWikiRepository _wikiPages;
     private readonly ClientSecretDistributionService _secretDistribution;
@@ -34,7 +34,7 @@ public class CreateModel : PageModel
         RealmsService realms,
         ClientsService clients,
         UserClientsRepository repo,
-        ServiceRoleExclusionsRepository exclusions,
+        IServiceRoleExclusionsRepository exclusions,
         ConfluenceWikiService wiki,
         ClientWikiRepository wikiPages,
         ClientSecretDistributionService secretDistribution,

--- a/Program.cs
+++ b/Program.cs
@@ -38,7 +38,7 @@ builder.Services.AddScoped<Assistant.KeyCloak.UsersService>();
 builder.Services.AddScoped<Assistant.KeyCloak.EventsService>();
 builder.Services.AddSingleton<UserClientsRepository>();
 builder.Services.AddSingleton<IUserClientsRepository>(sp => sp.GetRequiredService<UserClientsRepository>());
-builder.Services.AddSingleton<ServiceRoleExclusionsRepository>();
+builder.Services.AddSingleton<IServiceRoleExclusionsRepository, ServiceRoleExclusionsRepository>();
 builder.Services.AddSingleton<ApiLogRepository>();
 builder.Services.AddSingleton<ClientWikiRepository>();
 builder.Services.AddScoped<IClientsProvider, DbClientsProvider>();

--- a/Services/IServiceRoleExclusionsRepository.cs
+++ b/Services/IServiceRoleExclusionsRepository.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Primitives;
+
+namespace Assistant.Services;
+
+public interface IServiceRoleExclusionsRepository
+{
+    Task<HashSet<string>> GetAllAsync(CancellationToken ct = default);
+
+    Task<bool> IsExcludedAsync(string clientId, CancellationToken ct = default);
+
+    Task<bool> AddAsync(string clientId, CancellationToken ct = default);
+
+    Task<string?> RemoveAsync(string clientId, CancellationToken ct = default);
+
+    long GetVersion();
+
+    IChangeToken CreateChangeToken();
+}

--- a/Tests/Assistant.Tests/Assistant.Tests.csproj
+++ b/Tests/Assistant.Tests/Assistant.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Assistant.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/Assistant.Tests/ClientsServiceCachingTests.cs
+++ b/Tests/Assistant.Tests/ClientsServiceCachingTests.cs
@@ -1,0 +1,193 @@
+using Assistant.KeyCloak;
+using Assistant.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace Assistant.Tests;
+
+public class ClientsServiceCachingTests
+{
+    [Fact]
+    public async Task SearchClientsAsync_RefreshesCache_WhenExclusionsChange()
+    {
+        var clients = new[]
+        {
+            new { id = "1", clientId = "alpha" },
+            new { id = "2", clientId = "beta" }
+        };
+        var clientsJson = JsonSerializer.Serialize(clients);
+
+        using var handler = new StaticHttpMessageHandler(request =>
+        {
+            if (request.RequestUri?.Query?.Contains("search=true", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return CreateJsonResponse(clientsJson);
+            }
+
+            return CreateJsonResponse("[]");
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var httpClientFactory = new FakeHttpClientFactory(httpClient);
+        var options = Options.Create(new AdminApiOptions { BaseUrl = "https://kc.example" });
+        var exclusions = new StubServiceRoleExclusionsRepository();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Username=test;Password=test;Database=test"
+            })
+            .Build();
+
+        var logs = new ApiLogRepository(configuration);
+        var httpContextAccessor = new HttpContextAccessor();
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        var service = new ClientsService(
+            httpClientFactory,
+            options,
+            exclusions,
+            logs,
+            httpContextAccessor,
+            memoryCache);
+
+        var initial = await service.SearchClientsAsync("master", "client", ct: default);
+        Assert.Equal(new[] { "alpha", "beta" }, initial.Select(c => c.ClientId).ToArray());
+
+        var added = await exclusions.AddAsync("beta", default);
+        Assert.True(added);
+
+        var updated = await service.SearchClientsAsync("master", "client", ct: default);
+        Assert.Equal(new[] { "alpha" }, updated.Select(c => c.ClientId).ToArray());
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(string json)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class FakeHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public FakeHttpClientFactory(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public HttpClient CreateClient(string name) => _client;
+    }
+
+    private sealed class StaticHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        public StaticHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_responder(request));
+    }
+
+    private sealed class StubServiceRoleExclusionsRepository : IServiceRoleExclusionsRepository
+    {
+        private readonly object _sync = new();
+        private readonly HashSet<string> _clients = new(StringComparer.OrdinalIgnoreCase);
+        private long _version;
+        private CancellationTokenSource _cts = new();
+
+        public Task<HashSet<string>> GetAllAsync(CancellationToken ct = default)
+        {
+            lock (_sync)
+            {
+                return Task.FromResult(new HashSet<string>(_clients, StringComparer.OrdinalIgnoreCase));
+            }
+        }
+
+        public Task<bool> IsExcludedAsync(string clientId, CancellationToken ct = default)
+        {
+            lock (_sync)
+            {
+                return Task.FromResult(_clients.Contains(clientId));
+            }
+        }
+
+        public Task<bool> AddAsync(string clientId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                return Task.FromResult(false);
+            }
+
+            lock (_sync)
+            {
+                if (_clients.Add(clientId))
+                {
+                    TriggerChange();
+                    return Task.FromResult(true);
+                }
+            }
+
+            return Task.FromResult(false);
+        }
+
+        public Task<string?> RemoveAsync(string clientId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                return Task.FromResult<string?>(null);
+            }
+
+            lock (_sync)
+            {
+                if (_clients.Remove(clientId))
+                {
+                    TriggerChange();
+                    return Task.FromResult<string?>(clientId);
+                }
+            }
+
+            return Task.FromResult<string?>(null);
+        }
+
+        public long GetVersion()
+        {
+            lock (_sync)
+            {
+                return _version;
+            }
+        }
+
+        public IChangeToken CreateChangeToken()
+        {
+            lock (_sync)
+            {
+                return new CancellationChangeToken(_cts.Token);
+            }
+        }
+
+        private void TriggerChange()
+        {
+            var oldCts = _cts;
+            _cts = new CancellationTokenSource();
+            _version++;
+
+            oldCts.Cancel();
+            oldCts.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a change-token aware interface for the service role exclusions repository and increment a version whenever exclusions mutate
- tie repository and Keycloak client search caches to the change token/version so searches are refreshed after exclusions change
- cover the cache behaviour with a new xUnit test project verifying client searches update immediately

## Testing
- `dotnet test Tests/Assistant.Tests/Assistant.Tests.csproj` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dab4be5e70832d9b89ad5ce9d34ade