### PR TITLE
Ensure service role exclusion updates invalidate cached client searches

### DIFF
--- a/Pages/Admin/ServiceRoleExclusions.cshtml.cs
+++ b/Pages/Admin/ServiceRoleExclusions.cshtml.cs
@@ -206,8 +206,8 @@ public sealed class ServiceRoleExclusionsModel : PageModel
 
     private async Task LoadExclusionsAsync(CancellationToken ct)
     {
-        var set = await _repository.GetAllAsync(ct);
-        Exclusions = set
+        var snapshot = await _repository.GetAllAsync(ct);
+        Exclusions = snapshot.ClientIds
             .OrderBy(clientId => clientId, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }

--- a/Pages/Clients/ClientFormUtilities.cs
+++ b/Pages/Clients/ClientFormUtilities.cs
@@ -104,7 +104,7 @@ internal static class ClientFormUtilities
     public static IEnumerable<string> FindInvalidLocalRoles(IEnumerable<string> localRoles)
         => localRoles.Where(role => !RoleNameRegex.IsMatch(role));
 
-    public static IEnumerable<string> FindInvalidServiceRoleEntries(IEnumerable<string> entries, ISet<string> restrictedClients)
+    public static IEnumerable<string> FindInvalidServiceRoleEntries(IEnumerable<string> entries, IReadOnlySet<string> restrictedClients)
     {
         foreach (var entry in entries)
         {

--- a/Pages/Clients/Create.cshtml.cs
+++ b/Pages/Clients/Create.cshtml.cs
@@ -247,8 +247,8 @@ public class CreateModel : PageModel
 
         var svcEntries = ClientFormUtilities.NormalizeDistinct(ClientFormUtilities.ParseStringList(ServiceRolesJson));
         ServiceRolesJson = JsonSerializer.Serialize(svcEntries);
-        var restrictedClients = await _exclusions.GetAllAsync(ct);
-        var badSvc = ClientFormUtilities.FindInvalidServiceRoleEntries(svcEntries, restrictedClients).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var restrictedSnapshot = await _exclusions.GetAllAsync(ct);
+        var badSvc = ClientFormUtilities.FindInvalidServiceRoleEntries(svcEntries, restrictedSnapshot.ClientIds).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         if (badSvc.Any())
         {
             ModelState.AddModelError(nameof(ServiceRolesJson), $"Некорректные сервисные роли: {string.Join(", ", badSvc)}");


### PR DESCRIPTION
## Summary
- add version-aware change tracking to `ServiceRoleExclusionsRepository` and expose a snapshot that carries exclusions and change tokens
- update client search/list flows to bind cache entries to the exclusion snapshot and react to version bumps
- adjust Razor page helpers and tests to consume the snapshot API and verify that exclusion updates invalidate cached searches

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dacc68f5d0832d8a32c2e5341b549d