### PR TITLE
Improve service roles search error handling

### DIFF
--- a/wwwroot/js/service-roles.js
+++ b/wwwroot/js/service-roles.js
@@ -294,11 +294,48 @@ export function initServiceRoles(root, options = {}) {
         if (signal && !finalInit.signal) {
             finalInit.signal = signal;
         }
+
         const response = await fetch(url, finalInit);
+        const contentType = (response.headers.get('content-type') || '').toLowerCase();
+        const rawBody = await response.text();
+        const createSnippet = () => {
+            const trimmed = rawBody.trim();
+            if (!trimmed) {
+                return '';
+            }
+            return trimmed.replace(/\s+/g, ' ').slice(0, 120);
+        };
+
         if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
+            const snippet = createSnippet();
+            throw new Error(snippet ? `HTTP ${response.status} (${snippet})` : `HTTP ${response.status}`);
         }
-        return response.json();
+
+        if (rawBody === '') {
+            return null;
+        }
+
+        const tryParseJson = () => {
+            try {
+                return JSON.parse(rawBody);
+            } catch (error) {
+                const snippet = createSnippet();
+                throw new Error(snippet ? `Не удалось разобрать ответ сервера (${snippet})` : 'Не удалось разобрать ответ сервера.');
+            }
+        };
+
+        if (!contentType.includes('json')) {
+            try {
+                const data = tryParseJson();
+                console.warn('[ServiceRolesUI] Unexpected content type for JSON payload:', contentType || '<empty>');
+                return data;
+            } catch (error) {
+                const snippet = createSnippet();
+                throw new Error(snippet ? `Некорректный ответ сервера (${snippet})` : 'Некорректный ответ сервера.');
+            }
+        }
+
+        return tryParseJson();
     };
 
     const ensureMoreHitsButton = (token) => {


### PR DESCRIPTION
## Summary
- add defensive JSON parsing in the service roles search helper
- provide clearer error messages when the backend responds with non-JSON payloads
- allow parsing JSON responses even when the server sends an incorrect content type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc030ba28c832d9c47835158d40129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens fetch JSON handling with tolerant parsing and clearer error messages in `wwwroot/js/service-roles.js`.
> 
> - **Service Roles UI**:
>   - **`fetchJson` robustness** in `wwwroot/js/service-roles.js`:
>     - Reads raw body, returns `null` on empty responses.
>     - Adds HTTP error messages with response snippet.
>     - Parses JSON even when `content-type` is incorrect; logs a warning.
>     - Improves parse failures with clearer, localized error messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da308a2b5ab135a6fefec3de793c02faa3759079. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->