### PR TITLE
Fix service roles search client context

### DIFF
--- a/Pages/Clients/Details.cshtml
+++ b/Pages/Clients/Details.cshtml
@@ -1157,6 +1157,7 @@
                 pageUrl: '@Url.Page(null)',
                 hiddenInput,
                 getRealm: () => '@realm',
+                pageClientId: '@clientId',
                 initialRoles: Array.isArray(initialRoles) ? initialRoles : []
             });
         }


### PR DESCRIPTION
## Summary
- include the current client identifier when invoking the service roles search endpoints so the Razor handlers authorize the request
- add optional `pageClientId` wiring to `initServiceRoles` and pass it from the client details page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc030ba28c832d9c47835158d40129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 521eb464a7f01d753b1c59d0c5deadd797571457. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->